### PR TITLE
Test Framework: allow constrained random testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,14 @@ FC_SRCS = \
 	src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_i32_parallel.c \
 	src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_i16_parallel.c \
 	src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_i8_parallel.c \
+	src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q32.c src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q32s_rv32im.c \
+	src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q16.c src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q16s_rv32im.c \
+	src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q8.c src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q8s_rv32im.c \
+	src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q32_parallel.c \
+	src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q16_parallel.c \
+	src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q8_parallel.c \
+	src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_f32.c \
+	src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_f32_parallel.c \
 	src/TransformFunctions/plp_rfft_f32.c \
 	src/TransformFunctions/plp_rfft_f32_parallel.c
 
@@ -102,6 +110,14 @@ CL_SRCS = \
 	src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_i32p_xpulpv2.c \
 	src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_i16vp_xpulpv2.c \
 	src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_i8vp_xpulpv2.c	\
+	src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q32s_xpulpv2.c \
+	src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q16v_xpulpv2.c \
+	src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q8v_xpulpv2.c \
+	src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q32p_xpulpv2.c \
+	src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q16vp_xpulpv2.c \
+	src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q8vp_xpulpv2.c	\
+	src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_f32s_xpulpv2.c \
+	src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_f32p_xpulpv2.c \
 	src/TransformFunctions/kernels/plp_rfft_f32_xpulpv2.c
 
 

--- a/include/plp_math.h
+++ b/include/plp_math.h
@@ -2662,6 +2662,494 @@ void plp_mat_mult_trans_i8_parallel(
 void plp_mat_mult_trans_i8vp_xpulpv2(
                          void* args);
 
+
+
+/** -------------------------------------------------------
+   @brief         Glue code for matrix transposed matrix multiplication of a 32-bit fix-point matrices.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[in]     shift      Amount to shift the result of each multiplication.
+   @param[out]    pDstC      Output is written here
+   @return        none
+
+   @par Fix-Point and Shifting
+   The result will be shifted by the parameter `shift` to the right (multiplied
+   by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+   B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+   point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+ */
+
+void plp_mat_mult_trans_q32(
+                         const int32_t * __restrict__ pSrcA,
+                         const int32_t * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         uint32_t shift,
+                         int32_t * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+   @brief         Glue code for parallel matrix transposed matrix multiplication of a 32-bit fix-point matrices.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[in]     shift      Amount to shift the result of each multiplication.
+   @param[in]     nPE        Number of cores to use
+   @param[out]    pDstC      Output is written here
+   @return        none
+
+   @par Fix-Point and Shifting
+   The result will be shifted by the parameter `shift` to the right (multiplied
+   by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+   B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+   point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+ */
+
+void plp_mat_mult_trans_q32_parallel(
+                         const int32_t * __restrict__ pSrcA,
+                         const int32_t * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         uint32_t shift,
+                         uint32_t nPE,
+                         int32_t * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+   @brief         matrix transposed matrix multiplication of a 32-bit fix-point matrices for RV32IM extension.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[in]     shift      Amount to shift the result of each multiplication.
+   @param[out]    pDstC      Output is written here
+   @return        none
+
+   @par Fix-Point and Shifting
+   The result will be shifted by the parameter `shift` to the right (multiplied
+   by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+   B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+   point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+*/
+
+void plp_mat_mult_trans_q32s_rv32im(
+                         const int32_t * __restrict__ pSrcA,
+                         const int32_t * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         uint32_t shift,
+                         int32_t * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+   @brief         matrix transposed matrix multiplication of a 32-bit fix-point matrices for XPULPV2 extension.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[in]     shift      Amount to shift the result of each multiplication.
+   @param[out]    pDstC      Output is written here
+   @return        none
+
+   @par Fix-Point and Shifting
+   The result will be shifted by the parameter `shift` to the right (multiplied
+   by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+   B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+   point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+*/
+
+void plp_mat_mult_trans_q32s_xpulpv2(
+                         const int32_t * __restrict__ pSrcA,
+                         const int32_t * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         uint32_t shift,
+                         int32_t * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+    @brief Parallel matrix transposed matrix multiplication of 32-bit fix-point matrices kernel for XPULPV2 extension.
+    @param[in]  args      pointer to plp_mat_mult_instance_q32 struct initialized by plp_mat_mult_trans_q32_parallel
+    @return     none
+*/
+
+void plp_mat_mult_trans_q32p_xpulpv2(void* args);
+
+
+
+/** -------------------------------------------------------
+   @brief         Glue code for matrix transposed matrix multiplication of a 16-bit fix-point matrices.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[in]     shift      Amount to shift the result of each multiplication.
+   @param[out]    pDstC      Output is written here
+   @return        none
+
+   @par Fix-Point and Shifting
+   The result will be shifted by the parameter `shift` to the right (multiplied
+   by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+   B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+   point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 16-bit array.
+  Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q16(
+                         const int16_t * __restrict__ pSrcA,
+                         const int16_t * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         uint32_t shift,
+                         int16_t * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+   @brief         Glue code for parallel matrix transposed matrix multiplication of a 16-bit fix-point matrices.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[in]     shift      Amount to shift the result of each multiplication.
+   @param[in]     nPE        Number of cores to use
+   @param[out]    pDstC      Output is written here
+   @return        none
+
+   @par Fix-Point and Shifting
+   The result will be shifted by the parameter `shift` to the right (multiplied
+   by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+   B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+   point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 16-bit array.
+  Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q16_parallel(
+                         const int16_t * __restrict__ pSrcA,
+                         const int16_t * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         uint32_t shift,
+                         uint32_t nPE,
+                         int16_t * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+   @brief         matrix transposed matrix multiplication of a 16-bit fix-point matrices for RV32IM extension.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[in]     shift      Amount to shift the result of each multiplication.
+   @param[out]    pDstC      Output is written here
+   @return        none
+
+   @par Fix-Point and Shifting
+   The result will be shifted by the parameter `shift` to the right (multiplied
+   by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+   B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+   point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 16-bit array.
+  Set the `shift` parameter such that no overflow ocurrs.
+*/
+
+void plp_mat_mult_trans_q16s_rv32im(
+                         const int16_t * __restrict__ pSrcA,
+                         const int16_t * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         uint32_t shift,
+                         int16_t * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+   @brief         matrix transposed matrix multiplication of a 16-bit fix-point matrices for XPULPV2 extension.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[in]     shift      Amount to shift the result of each multiplication.
+   @param[out]    pDstC      Output is written here
+   @return        none
+
+   @par Fix-Point and Shifting
+   The result will be shifted by the parameter `shift` to the right (multiplied
+   by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+   B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+   point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 16-bit array.
+  Set the `shift` parameter such that no overflow ocurrs.
+*/
+
+void plp_mat_mult_trans_q16v_xpulpv2(
+                         const int16_t * __restrict__ pSrcA,
+                         const int16_t * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         uint32_t shift,
+                         int16_t * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+    @brief Parallel matrix transposed matrix multiplication of 16-bit fix-point matrices kernel for XPULPV2 extension.
+    @param[in]  args      pointer to plp_mat_mult_instance_q16 struct initialized by plp_mat_mult_trans_q16_parallel
+    @return     none
+*/
+
+void plp_mat_mult_trans_q16vp_xpulpv2(void* args);
+
+
+
+/** -------------------------------------------------------
+   @brief         Glue code for matrix transposed matrix multiplication of a 8-bit fix-point matrices.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[in]     shift      Amount to shift the result of each multiplication.
+   @param[out]    pDstC      Output is written here
+   @return        none
+
+   @par Fix-Point and Shifting
+   The result will be shifted by the parameter `shift` to the right (multiplied
+   by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+   B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+   point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 8-bit array.
+  Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q8(
+                         const int8_t * __restrict__ pSrcA,
+                         const int8_t * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         uint32_t shift,
+                         int8_t * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+   @brief         Glue code for parallel matrix transposed matrix multiplication of a 8-bit fix-point matrices.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[in]     shift      Amount to shift the result of each multiplication.
+   @param[in]     nPE        Number of cores to use
+   @param[out]    pDstC      Output is written here
+   @return        none
+
+   @par Fix-Point and Shifting
+   The result will be shifted by the parameter `shift` to the right (multiplied
+   by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+   B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+   point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 8-bit array.
+  Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q8_parallel(
+                         const int8_t * __restrict__ pSrcA,
+                         const int8_t * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         uint32_t shift,
+                         uint32_t nPE,
+                         int8_t * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+   @brief         matrix transposed matrix multiplication of a 8-bit fix-point matrices for RV32IM extension.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[in]     shift      Amount to shift the result of each multiplication.
+   @param[out]    pDstC      Output is written here
+   @return        none
+
+   @par Fix-Point and Shifting
+   The result will be shifted by the parameter `shift` to the right (multiplied
+   by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+   B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+   point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 8-bit array.
+  Set the `shift` parameter such that no overflow ocurrs.
+*/
+
+void plp_mat_mult_trans_q8s_rv32im(
+                         const int8_t * __restrict__ pSrcA,
+                         const int8_t * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         uint32_t shift,
+                         int8_t * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+   @brief         matrix transposed matrix multiplication of a 8-bit fix-point matrices for XPULPV2 extension.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[in]     shift      Amount to shift the result of each multiplication.
+   @param[out]    pDstC      Output is written here
+   @return        none
+
+   @par Fix-Point and Shifting
+   The result will be shifted by the parameter `shift` to the right (multiplied
+   by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+   B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+   point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 8-bit array.
+  Set the `shift` parameter such that no overflow ocurrs.
+*/
+
+void plp_mat_mult_trans_q8v_xpulpv2(
+                         const int8_t * __restrict__ pSrcA,
+                         const int8_t * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         uint32_t shift,
+                         int8_t * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+    @brief Parallel matrix transposed matrix multiplication of 8-bit fix-point matrices kernel for XPULPV2 extension.
+    @param[in]  args      pointer to plp_mat_mult_instance_q8 struct initialized by plp_mat_mult_trans_q8_parallel
+    @return     none
+*/
+
+void plp_mat_mult_trans_q8vp_xpulpv2(void* args);
+
+
+/** -------------------------------------------------------
+   @brief         Glue code for matrix transposed matrix multiplication of a 32-bit floating-point matrices.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[out]    pDstC      Output is written here
+   @return        none
+*/
+
+
+void plp_mat_mult_trans_f32(
+                         const float * __restrict__ pSrcA,
+                         const float * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         float * __restrict__ pDstC);
+
+
+/** -------------------------------------------------------
+   @brief         matrix transposed matrix multiplication of a 32-bit floating-point matrices for XPULPV2 extension.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[out]    pDstC      Output is written here
+   @return        none
+*/
+
+void plp_mat_mult_trans_f32s_xpulpv2(
+                         const float * __restrict__ pSrcA,
+                         const float * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         float * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+   @brief         Glue code for parallel matrix transposed matrix multiplication of a 32-bit floating-point matrices.
+   @param[in]     pSrcA      points to first the input matrix
+   @param[in]     pSrcB      points to second the input matrix
+   @param[in]     M          Height of first matrix
+   @param[in]     N          Width of first and heigt of second matrix
+   @param[in]     O          Width of second matrix
+   @param[in]     nPE        Number of cores to use
+   @param[out]    pDstC      Output is written here
+   @return        none
+*/
+
+void plp_mat_mult_trans_f32_parallel(
+                         const float * __restrict__ pSrcA,
+                         const float * __restrict__ pSrcB,
+                         uint32_t M,
+                         uint32_t N,
+                         uint32_t O,
+                         uint32_t nPE,
+                         float * __restrict__ pDstC);
+
+
+
+/** -------------------------------------------------------
+    @brief Parallel matrix transposed matrix multiplication of 32-bit floating-point matrices kernel for XPULPV2 extension.
+    @param[in]  args      pointer to plp_mat_mult_instance_f32 struct initialized by plp_mat_mult_trans_f32_parallel
+    @return     none
+*/
+
+void plp_mat_mult_trans_f32p_xpulpv2(
+                         void* args);
+
+
+
+
+
+
 /**
    @brief Floating-point FFT on real input data.
    @param[in]   S       points to an instance of the floating-point FFT structure

--- a/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_f32p_xpulpv2.c
+++ b/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_f32p_xpulpv2.c
@@ -1,0 +1,91 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_f32p_xpulpv2.c
+ * Description:  32-bit integer matrix multiplication for XPULPV2
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup MatMultTrans
+ */
+
+
+/**
+  @addtogroup MatMultTransKernels
+  @{
+ */
+
+/**
+   @brief Parallel matrix multiplication of 32-bit floating-point matrices kernel for XPULPV2 extension.
+   @param[in]  args      pointer to plp_mat_mult_instance_f32 struct initialized by plp_mat_mult_trans_f32_parallel
+   @return        none
+*/
+
+void plp_mat_mult_trans_f32p_xpulpv2(void* args) {
+
+    int core_id = rt_core_id();
+
+    plp_mat_mult_instance_f32* a = (plp_mat_mult_instance_f32*)args;
+    
+    const float * __restrict__ pSrcA = a->pSrcA;
+    const float * __restrict__ pSrcB = a->pSrcB;
+    uint32_t M = a->M;
+    uint32_t N = a->N;
+    uint32_t O = a->O;
+    uint32_t nPE = a->nPE;
+    float * __restrict__ pDstC = a->pDstC;
+
+#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+#ifdef BASIC_VERSION
+
+    uint32_t m, n, o;
+
+    for(m = core_id; m < M; m += nPE){
+        for(o = 0; o < O; o++){
+            float sum = 0;
+            for(n = 0; n < N; n++){
+                sum = sum + pSrcA[m * N + n]*pSrcB[o * N + n];
+            }
+            pDstC[m * O + o] = sum;
+        }
+    }
+
+#else 
+
+    // TODO: Hackathon
+
+#endif
+#undef BASIC_VERSION
+
+}
+
+
+/**
+   @} end of MatMultTransKernels group
+*/

--- a/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_f32s_xpulpv2.c
+++ b/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_f32s_xpulpv2.c
@@ -1,0 +1,89 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_f32s_xpulpv2.c
+ * Description:  32-bit integer matrix multiplication for XPULPV2
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup MatMultTrans
+ */
+
+
+/**
+  @addtogroup MatMultTransKernels
+  @{
+ */
+
+/**
+  @brief Matrix multiplication of 32-bit floating-point matrices kernel for XPULPV2 extension.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[out] pDstC     points to the output matrix
+  @return     none
+ */
+
+void plp_mat_mult_trans_f32s_xpulpv2(const float * __restrict__ pSrcA,
+                                     const float * __restrict__ pSrcB,
+                                     uint32_t M,
+                                     uint32_t N,
+                                     uint32_t O,
+                                     float * __restrict__ pDstC) {
+
+#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+#ifdef BASIC_VERSION
+
+    uint32_t m, n, o;
+
+    for(m = 0; m < M; m++){
+        for(o = 0; o < O; o++){
+            float sum = 0;
+            for(n = 0; n < N; n++){
+                sum = sum + pSrcA[m * N + n]*pSrcB[o * N + n];
+            }
+            pDstC[m * O + o] = sum;
+        }
+    }
+
+#else 
+
+    // TODO: Hackathon
+
+#endif
+#undef BASIC_VERSION
+
+}
+
+
+/**
+   @} end of MatMultTransKernels group
+*/

--- a/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q16s_rv32im.c
+++ b/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q16s_rv32im.c
@@ -1,0 +1,105 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_q16s_rv32im.c
+ * Description:  32-bit integer matrix multiplication for XPULPV2
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup groupMatrix MatMultTrans
+ */
+
+
+/**
+  @addtogroup MatMultTransKernels
+  @{
+ */
+
+/**
+  @brief Matrix multiplication of 16-bit integer matrices kernel for RV32IM extension.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[in]  shift     Amount to shift the result of each multiplication.
+  @param[out] pDstC     points to the output matrix
+  @return        none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 16-bit
+  array. Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q16s_rv32im(const int16_t * __restrict__ pSrcA,
+                                    const int16_t * __restrict__ pSrcB,
+                                    uint32_t M,
+                                    uint32_t N,
+                                    uint32_t O,
+                                    uint32_t shift,
+                                    int16_t * __restrict__ pDstC) {
+
+#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+#ifdef BASIC_VERSION
+
+    int32_t round = 1 << (shift - 1);
+
+    uint32_t m; // loop counter
+    uint32_t n; // loop counter
+    uint32_t o; // loop counter
+
+    for(m = 0; m < M; m++){
+        for(o = 0; o < O; o++){
+            int32_t sum = 0;
+            for(n = 0; n < N; n++){
+                int32_t valA = (int32_t)pSrcA[m * N + n];
+                int32_t valB = (int32_t)pSrcB[o * N + n];
+                sum += (valA * valB + round) >> shift;
+            }
+            pDstC[m * O + o] = (int16_t)sum;
+        }
+    }
+
+#else 
+
+        // TODO hackathon
+
+#endif
+#undef BASIC_VERSION
+
+}
+
+/**
+   @} end of MatMultTransKernels group
+*/

--- a/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q16v_xpulpv2.c
+++ b/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q16v_xpulpv2.c
@@ -1,0 +1,103 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_q16p_xpulpv2.c
+ * Description:  32-bit integer matrix multiplication for XPULPV2
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup groupMatrix MatMultTrans
+ */
+
+
+/**
+  @addtogroup MatMultTransKernels
+  @{
+ */
+
+/**
+  @brief Matrix multiplication of 16-bit integer matrices kernel for XPULPV2 extension.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[in]  shift     Amount to shift the result of each multiplication.
+  @param[out] pDstC     points to the output matrix
+  @return        none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 16-bit
+  array. Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q16v_xpulpv2(const int16_t * __restrict__ pSrcA,
+                                     const int16_t * __restrict__ pSrcB,
+                                     uint32_t M,
+                                     uint32_t N,
+                                     uint32_t O,
+                                     uint32_t shift,
+                                     int16_t * __restrict__ pDstC) {
+
+#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+#ifdef BASIC_VERSION
+
+    uint32_t m; // loop counter
+    uint32_t n; // loop counter
+    uint32_t o; // loop counter
+
+    for(m = 0; m < M; m++){
+        for(o = 0; o < O; o++){
+            int32_t sum = 0;
+            for(n = 0; n < N; n++){
+                int32_t valA = (int32_t)pSrcA[m * N + n];
+                int32_t valB = (int32_t)pSrcB[o * N + n];
+                sum += __ROUNDNORM_REG(valA * valB, shift);
+            }
+            pDstC[m * O + o] = (int16_t)sum;
+        }
+    }
+
+#else 
+
+        // TODO hackathon
+
+#endif
+#undef BASIC_VERSION
+
+}
+
+/**
+   @} end of MatMultTransKernels group
+*/

--- a/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q16vp_xpulpv2.c
+++ b/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q16vp_xpulpv2.c
@@ -1,0 +1,104 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_q16vp_xpulpv2.c
+ * Description:  32-bit integer matrix multiplication for XPULPV2
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup groupMatrix MatMultTrans
+ */
+
+
+/**
+  @addtogroup MatMultTransKernels
+  @{
+ */
+
+/**
+  @brief Parallel Matrix multiplication of 16-bit fix-point matrices kernel for XPULPV2 extension.
+  @param[in]  args      pointer to plp_mat_mult_instance_q16 struct initialized by plp_mat_mult_trans_q16_parallel
+  @return     none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 16-bit
+  array. Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q16vp_xpulpv2(void* args) {
+
+    int core_id = rt_core_id();
+
+    plp_mat_mult_instance_q16* a = (plp_mat_mult_instance_q16*)args;
+    
+    const int16_t * __restrict__ pSrcA = a->pSrcA;
+    const int16_t * __restrict__ pSrcB = a->pSrcB;
+    uint32_t M = a->M;
+    uint32_t N = a->N;
+    uint32_t O = a->O;
+    uint32_t shift = a->shift;
+    uint32_t nPE = a->nPE;
+    int16_t * __restrict__ pDstC = a->pDstC;
+
+#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+#ifdef BASIC_VERSION
+
+    uint32_t m; // loop counter
+    uint32_t n; // loop counter
+    uint32_t o; // loop counter
+
+    for(m = core_id; m < M; m += nPE){
+        for(o = 0; o < O; o++){
+            int32_t sum = 0;
+            for(n = 0; n < N; n++){
+                int32_t valA = (int32_t)pSrcA[m * N + n];
+                int32_t valB = (int32_t)pSrcB[o * N + n];
+                sum += __ROUNDNORM_REG(valA * valB, shift);
+            }
+            pDstC[m * O + o] = (int16_t)sum;
+        }
+    }
+
+#else 
+
+        // TODO hackathon
+
+#endif
+#undef BASIC_VERSION
+
+}
+
+/**
+   @} end of MatMultTransKernels group
+*/

--- a/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q32p_xpulpv2.c
+++ b/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q32p_xpulpv2.c
@@ -1,0 +1,101 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_q32p_xpulpv2.c
+ * Description:  32-bit integer matrix multiplication for XPULPV2
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup groupMatrix MatMultTrans
+ */
+
+
+/**
+  @addtogroup MatMultTransKernels
+  @{
+ */
+
+/**
+  @brief Parallel Matrix multiplication of 32-bit fix-point matrices kernel for XPULPV2 extension.
+  @param[in]  args      pointer to plp_mat_mult_instance_q32 struct initialized by plp_mat_mult_trans_q32_parallel
+  @return     none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+ */
+
+void plp_mat_mult_trans_q32p_xpulpv2(void* args) {
+
+    int core_id = rt_core_id();
+
+    plp_mat_mult_instance_q32* a = (plp_mat_mult_instance_q32*)args;
+
+    const int32_t * __restrict__ pSrcA = a->pSrcA;
+    const int32_t * __restrict__ pSrcB = a->pSrcB;
+    uint32_t M = a->M;
+    uint32_t N = a->N;
+    uint32_t O = a->O;
+    uint32_t shift = a->shift;
+    uint32_t nPE = a->nPE;
+    int32_t * __restrict__ pDstC = a->pDstC;
+
+#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+#ifdef BASIC_VERSION
+
+    uint32_t m; // loop counter
+    uint32_t n; // loop counter
+    uint32_t o; // loop counter
+
+    for(m = core_id; m < M; m += nPE){
+        for(o = 0; o < O; o++){
+            int32_t sum = 0;
+            for(n = 0; n < N; n++){
+                int32_t valA = pSrcA[m * N + n];
+                int32_t valB = pSrcB[o * N + n];
+                sum += __ROUNDNORM_REG(valA * valB, shift);
+            }
+            pDstC[m * O + o] = sum;
+        }
+    }
+
+#else 
+
+        // TODO hackathon
+
+#endif
+#undef BASIC_VERSION
+
+}
+
+/**
+   @} end of MatMultTransKernels group
+*/

--- a/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q32s_rv32im.c
+++ b/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q32s_rv32im.c
@@ -1,0 +1,100 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_q32s_rv32im.c
+ * Description:  32-bit integer matrix multiplication for XPULPV2
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup groupMatrix MatMultTrans
+ */
+
+
+/**
+  @addtogroup MatMultTransKernels
+  @{
+ */
+
+/**
+  @brief Matrix multiplication of 32-bit integer matrices kernel for RV32IM extension.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[in]  shift     Amount to shift the result of each multiplication.
+  @param[out] pDstC     points to the output matrix
+  @return        none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+ */
+
+void plp_mat_mult_trans_q32s_rv32im(const int32_t * __restrict__ pSrcA,
+                                    const int32_t * __restrict__ pSrcB,
+                                    uint32_t M,
+                                    uint32_t N,
+                                    uint32_t O,
+                                    uint32_t shift,
+                                    int32_t * __restrict__ pDstC) {
+
+#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+#ifdef BASIC_VERSION
+
+    int32_t round = 1 << (shift - 1);
+
+    uint32_t m; // loop counter
+    uint32_t n; // loop counter
+    uint32_t o; // loop counter
+
+    for(m = 0; m < M; m++){
+        for(o = 0; o < O; o++){
+            int32_t sum = 0;
+            for(n = 0; n < N; n++){
+                sum += (pSrcA[m * N + n] * pSrcB[o * N + n] + round) >> shift;
+            }
+            pDstC[m * O + o] = sum;
+        }
+    }
+
+#else 
+
+        // TODO hackathon
+
+#endif
+#undef BASIC_VERSION
+
+}
+
+/**
+   @} end of MatMultTransKernels group
+*/

--- a/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q32s_xpulpv2.c
+++ b/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q32s_xpulpv2.c
@@ -1,0 +1,98 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_q32s_xpulpv2.c
+ * Description:  32-bit integer matrix multiplication for XPULPV2
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup groupMatrix MatMultTrans
+ */
+
+
+/**
+  @addtogroup MatMultTransKernels
+  @{
+ */
+
+/**
+  @brief Matrix multiplication of 32-bit integer matrices kernel for XPULPV2 extension.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[in]  shift     Amount to shift the result of each multiplication.
+  @param[out] pDstC     points to the output matrix
+  @return        none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+ */
+
+void plp_mat_mult_trans_q32s_xpulpv2(const int32_t * __restrict__ pSrcA,
+                               const int32_t * __restrict__ pSrcB,
+                               uint32_t M,
+                               uint32_t N,
+                               uint32_t O,
+                               uint32_t shift,
+                               int32_t * __restrict__ pDstC) {
+
+#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+#ifdef BASIC_VERSION
+
+    uint32_t m; // loop counter
+    uint32_t n; // loop counter
+    uint32_t o; // loop counter
+
+    for(m = 0; m < M; m++){
+        for(o = 0; o < O; o++){
+            int32_t sum = 0;
+            for(n = 0; n < N; n++){
+                sum += __ROUNDNORM_REG(pSrcA[m * N + n] * pSrcB[o * N + n], shift);
+            }
+            pDstC[m * O + o] = sum;
+        }
+    }
+
+#else 
+
+        // TODO hackathon
+
+#endif
+#undef BASIC_VERSION
+
+}
+
+/**
+   @} end of MatMultTransKernels group
+*/

--- a/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q8s_rv32im.c
+++ b/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q8s_rv32im.c
@@ -1,0 +1,105 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_q8s_rv32im.c
+ * Description:  32-bit integer matrix multiplication for XPULPV2
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup groupMatrix MatMultTrans
+ */
+
+
+/**
+  @addtogroup MatMultTransKernels
+  @{
+ */
+
+/**
+  @brief Matrix multiplication of 8-bit integer matrices kernel for RV32IM extension.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[in]  shift     Amount to shift the result of each multiplication.
+  @param[out] pDstC     points to the output matrix
+  @return        none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 8-bit
+  array. Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q8s_rv32im(const int8_t * __restrict__ pSrcA,
+                                   const int8_t * __restrict__ pSrcB,
+                                   uint32_t M,
+                                   uint32_t N,
+                                   uint32_t O,
+                                   uint32_t shift,
+                                   int8_t * __restrict__ pDstC) {
+
+#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+#ifdef BASIC_VERSION
+
+    int32_t round = 1 << (shift - 1);
+
+    uint32_t m; // loop counter
+    uint32_t n; // loop counter
+    uint32_t o; // loop counter
+
+    for(m = 0; m < M; m++){
+        for(o = 0; o < O; o++){
+            int32_t sum = 0;
+            for(n = 0; n < N; n++){
+                int32_t valA = (int32_t)pSrcA[m * N + n];
+                int32_t valB = (int32_t)pSrcB[o * N + n];
+                sum += (valA * valB + round) >> shift;
+            }
+            pDstC[m * O + o] = (int8_t)sum;
+        }
+    }
+
+#else 
+
+        // TODO hackathon
+
+#endif
+#undef BASIC_VERSION
+
+}
+
+/**
+   @} end of MatMultTransKernels group
+*/

--- a/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q8v_xpulpv2.c
+++ b/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q8v_xpulpv2.c
@@ -1,0 +1,103 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_q8v_xpulpv2.c
+ * Description:  32-bit integer matrix multiplication for XPULPV2
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup groupMatrix MatMultTrans
+ */
+
+
+/**
+  @addtogroup MatMultTransKernels
+  @{
+ */
+
+/**
+  @brief Matrix multiplication of 8-bit integer matrices kernel for XPULPV2 extension.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[in]  shift     Amount to shift the result of each multiplication.
+  @param[out] pDstC     points to the output matrix
+  @return        none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 8-bit
+  array. Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q8v_xpulpv2(const int8_t * __restrict__ pSrcA,
+                                    const int8_t * __restrict__ pSrcB,
+                                    uint32_t M,
+                                    uint32_t N,
+                                    uint32_t O,
+                                    uint32_t shift,
+                                    int8_t * __restrict__ pDstC) {
+
+#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+#ifdef BASIC_VERSION
+
+    uint32_t m; // loop counter
+    uint32_t n; // loop counter
+    uint32_t o; // loop counter
+
+    for(m = 0; m < M; m++){
+        for(o = 0; o < O; o++){
+            int32_t sum = 0;
+            for(n = 0; n < N; n++){
+                int32_t valA = (int32_t)pSrcA[m * N + n];
+                int32_t valB = (int32_t)pSrcB[o * N + n];
+                sum += __ROUNDNORM_REG(valA * valB, shift);
+            }
+            pDstC[m * O + o] = (int8_t)sum;
+        }
+    }
+
+#else 
+
+        // TODO hackathon
+
+#endif
+#undef BASIC_VERSION
+
+}
+
+/**
+   @} end of MatMultTransKernels group
+*/

--- a/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q8vp_xpulpv2.c
+++ b/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_q8vp_xpulpv2.c
@@ -1,0 +1,104 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_q8vp_xpulpv2.c
+ * Description:  32-bit integer matrix multiplication for XPULPV2
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup groupMatrix MatMultTrans
+ */
+
+
+/**
+  @addtogroup MatMultTransKernels
+  @{
+ */
+
+/**
+  @brief Parallel Matrix multiplication of 8-bit fix-point matrices kernel for XPULPV2 extension.
+  @param[in]  args      pointer to plp_mat_mult_instance_q8 struct initialized by plp_mat_mult_trans_q8_parallel
+  @return     none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 8-bit
+  array. Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q8vp_xpulpv2(void* args) {
+
+    int core_id = rt_core_id();
+
+    plp_mat_mult_instance_q8* a = (plp_mat_mult_instance_q8*)args;
+    
+    const int8_t * __restrict__ pSrcA = a->pSrcA;
+    const int8_t * __restrict__ pSrcB = a->pSrcB;
+    uint32_t M = a->M;
+    uint32_t N = a->N;
+    uint32_t O = a->O;
+    uint32_t shift = a->shift;
+    uint32_t nPE = a->nPE;
+    int8_t * __restrict__ pDstC = a->pDstC;
+
+#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+#ifdef BASIC_VERSION
+
+    uint32_t m; // loop counter
+    uint32_t n; // loop counter
+    uint32_t o; // loop counter
+
+    for(m = core_id; m < M; m += nPE){
+        for(o = 0; o < O; o++){
+            int32_t sum = 0;
+            for(n = 0; n < N; n++){
+                int32_t valA = (int32_t)pSrcA[m * N + n];
+                int32_t valB = (int32_t)pSrcB[o * N + n];
+                sum += __ROUNDNORM_REG(valA * valB, shift);
+            }
+            pDstC[m * O + o] = (int8_t)sum;
+        }
+    }
+
+#else 
+
+        // TODO hackathon
+
+#endif
+#undef BASIC_VERSION
+
+}
+
+/**
+   @} end of MatMultTransKernels group
+*/

--- a/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_f32.c
+++ b/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_f32.c
@@ -1,0 +1,75 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_f32.c
+ * Description:  32-bit integer matrix multiplication glue code
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+   @ingroup groupMatrix
+ */
+
+/**
+  @addtogroup MatMultTrans
+  @{
+ */
+
+/**
+  @brief Glue code for matrix mutliplication of 32-bit floating-point matrices.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[out] pDstC     points to the output matrix
+  @return        none
+ */
+
+void plp_mat_mult_trans_f32(const float * __restrict__ pSrcA,
+                            const float * __restrict__ pSrcB,
+                            uint32_t M,
+                            uint32_t N,
+                            uint32_t O,
+                            float * __restrict__ pDstC) {
+
+    if (rt_cluster_id() == ARCHI_FC_CID){
+        printf("Floating point is supported only for cluster side\n");
+        return;
+    }
+    else{
+        plp_mat_mult_trans_f32s_xpulpv2(pSrcA, pSrcB, M, N, O, pDstC);
+    }
+
+}
+
+/**
+  @} end of MatMultTrans group
+ */
+
+

--- a/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_f32_parallel.c
+++ b/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_f32_parallel.c
@@ -1,0 +1,85 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_f32_parallel.c
+ * Description:  parallel 32-bit integer matrix multiplication glue code
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup groupMatrix
+ */
+
+
+/**
+  @addtogroup MatMultTrans
+  @{
+ */
+
+/**
+  @brief Glue code for parallel matrix mutliplication of 32-bit floating-point matrices.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[in]  nPE       Number of cores to use
+  @param[out] pDstC     points to the output matrix
+  @return        none
+ */
+
+void plp_mat_mult_trans_f32_parallel(const float * __restrict__ pSrcA,
+                                     const float * __restrict__ pSrcB,
+                                     uint32_t M,
+                                     uint32_t N,
+                                     uint32_t O,
+                                     uint32_t nPE,
+                                     float * __restrict__ pDstC) {
+
+    if (rt_cluster_id() == ARCHI_FC_CID){
+        printf("parallel and floating-point processing supported only for cluster side\n");
+        return;
+    }
+    else{
+        plp_mat_mult_instance_f32 args = {.pSrcA = pSrcA,
+                                          .pSrcB = pSrcB,
+                                          .M = M,
+                                          .N = N,
+                                          .O = O,
+                                          .nPE = nPE,
+                                          .pDstC = pDstC};
+        rt_team_fork(nPE,plp_mat_mult_trans_f32p_xpulpv2, (void*) &args);
+    }
+
+}
+
+/**
+  @} end of MatMultTrans group
+ */
+
+

--- a/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q16.c
+++ b/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q16.c
@@ -1,0 +1,85 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_q16.c
+ * Description:  32-bit integer matrix multiplication glue code
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+   @ingroup groupMatrix
+ */
+
+/**
+  @addtogroup MatMultTrans
+  @{
+ */
+
+/**
+  @brief Glue code for matrix mutliplication of 16-bit fix-point matrices.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[in]  shift     Amount to shift the result of each multiplication.
+  @param[out] pDstC     points to the output matrix
+  @return        none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 16-bit
+  array. Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q16(const int16_t * __restrict__ pSrcA,
+                            const int16_t * __restrict__ pSrcB,
+                            uint32_t M,
+                            uint32_t N,
+                            uint32_t O,
+                            uint32_t shift,
+                            int16_t * __restrict__ pDstC) {
+
+    if (rt_cluster_id() == ARCHI_FC_CID){
+        plp_mat_mult_trans_q16s_rv32im(pSrcA, pSrcB, M, N, O, shift, pDstC);
+    }
+    else{
+        plp_mat_mult_trans_q16v_xpulpv2(pSrcA, pSrcB, M, N, O, shift, pDstC);
+    }
+
+}
+
+/**
+  @} end of MatMultTrans group
+ */
+
+

--- a/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q16_parallel.c
+++ b/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q16_parallel.c
@@ -1,0 +1,99 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_q16_parallel.c
+ * Description:  parallel 8-bit integer matrix multiplication glue code
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup groupMatrix
+ */
+
+
+/**
+  @addtogroup MatMultTrans
+  @{
+ */
+
+/**
+  @brief Glue code for parallel matrix mutliplication of 16-bit fix-point matrices.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[in]  shift     Amount to shift the result of each multiplication.
+  @param[in]  nPE       Number of cores to use
+  @param[out] pDstC     points to the output matrix
+  @return        none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 16-bit array.
+  Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q16_parallel(const int16_t * __restrict__ pSrcA,
+                                     const int16_t * __restrict__ pSrcB,
+                                     uint32_t M,
+                                     uint32_t N,
+                                     uint32_t O,
+                                     uint32_t shift,
+                                     uint32_t nPE,
+                                     int16_t * __restrict__ pDstC){
+  
+  if (rt_cluster_id() == ARCHI_FC_CID){
+    printf("parallel processing supported only for cluster side\n");
+    return;
+  }
+  else{
+    plp_mat_mult_instance_q16 args = {
+      .pSrcA = pSrcA,
+      .pSrcB = pSrcB,
+      .M = M,
+      .N = N,
+      .O = O,
+      .shift = shift,
+      .nPE = nPE,
+      .pDstC = pDstC
+    };
+    rt_team_fork(nPE,plp_mat_mult_trans_q16vp_xpulpv2, (void*) &args);
+  }
+
+}
+
+/**
+  @} end of MatMultTrans group
+ */
+
+

--- a/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q32.c
+++ b/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q32.c
@@ -1,0 +1,82 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_q32.c
+ * Description:  32-bit integer matrix multiplication glue code
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+   @ingroup groupMatrix
+ */
+
+/**
+  @addtogroup MatMultTrans
+  @{
+ */
+
+/**
+  @brief Glue code for matrix mutliplication of 32-bit fix-point matrices.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[in]  shift     Amount to shift the result of each multiplication.
+  @param[out] pDstC     points to the output matrix
+  @return        none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+ */
+
+void plp_mat_mult_trans_q32(const int32_t * __restrict__ pSrcA,
+                            const int32_t * __restrict__ pSrcB,
+                            uint32_t M,
+                            uint32_t N,
+                            uint32_t O,
+                            uint32_t shift,
+                            int32_t * __restrict__ pDstC) {
+
+    if (rt_cluster_id() == ARCHI_FC_CID){
+        plp_mat_mult_trans_q32s_rv32im(pSrcA, pSrcB, M, N, O, shift, pDstC);
+    }
+    else{
+        plp_mat_mult_trans_q32s_xpulpv2(pSrcA, pSrcB, M, N, O, shift, pDstC);
+    }
+
+}
+
+/**
+  @} end of MatMultTrans group
+ */
+
+

--- a/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q32_parallel.c
+++ b/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q32_parallel.c
@@ -1,0 +1,96 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_i8_parallel.c
+ * Description:  parallel 8-bit integer matrix multiplication glue code
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup groupMatrix
+ */
+
+
+/**
+  @addtogroup MatMultTrans
+  @{
+ */
+
+/**
+  @brief Glue code for parallel matrix mutliplication of 32-bit fix-point matrices.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[in]  shift     Amount to shift the result of each multiplication.
+  @param[in]  nPE       Number of cores to use
+  @param[out] pDstC     points to the output matrix
+  @return        none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+ */
+
+void plp_mat_mult_trans_q32_parallel(const int32_t * __restrict__ pSrcA,
+                                     const int32_t * __restrict__ pSrcB,
+                                     uint32_t M,
+                                     uint32_t N,
+                                     uint32_t O,
+                                     uint32_t shift,
+                                     uint32_t nPE,
+                                     int32_t * __restrict__ pDstC){
+  
+  if (rt_cluster_id() == ARCHI_FC_CID){
+    printf("parallel processing supported only for cluster side\n");
+    return;
+  }
+  else{
+    plp_mat_mult_instance_q32 args = {
+      .pSrcA = pSrcA,
+      .pSrcB = pSrcB,
+      .M = M,
+      .N = N,
+      .O = O,
+      .shift = shift,
+      .nPE = nPE,
+      .pDstC = pDstC
+    };
+    rt_team_fork(nPE,plp_mat_mult_trans_q32p_xpulpv2, (void*) &args);
+  }
+
+}
+
+/**
+  @} end of MatMultTrans group
+ */
+
+

--- a/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q8.c
+++ b/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q8.c
@@ -1,0 +1,85 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_q8.c
+ * Description:  32-bit integer matrix multiplication glue code
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+   @ingroup groupMatrix
+ */
+
+/**
+  @addtogroup MatMultTrans
+  @{
+ */
+
+/**
+  @brief Glue code for matrix mutliplication of 8-bit fix-point matrices.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[in]  shift     Amount to shift the result of each multiplication.
+  @param[out] pDstC     points to the output matrix
+  @return        none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 8-bit array.
+  Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q8(const int8_t * __restrict__ pSrcA,
+                           const int8_t * __restrict__ pSrcB,
+                           uint32_t M,
+                           uint32_t N,
+                           uint32_t O,
+                           uint32_t shift,
+                           int8_t * __restrict__ pDstC) {
+
+    if (rt_cluster_id() == ARCHI_FC_CID){
+        plp_mat_mult_trans_q8s_rv32im(pSrcA, pSrcB, M, N, O, shift, pDstC);
+    }
+    else{
+        plp_mat_mult_trans_q8v_xpulpv2(pSrcA, pSrcB, M, N, O, shift, pDstC);
+    }
+
+}
+
+/**
+  @} end of MatMultTrans group
+ */
+
+

--- a/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q8_parallel.c
+++ b/src/MatrixFunctions/mat_mult_trans/plp_mat_mult_trans_q8_parallel.c
@@ -1,0 +1,99 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_mat_mult_trans_q8_parallel.c
+ * Description:  parallel 8-bit integer matrix multiplication glue code
+ *
+ * $Date:        18. July 2019
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and Ubiversity of Bologna. All rights reserved.
+ *
+ * Author: Tibor Schneider, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+
+/**
+  @ingroup groupMatrix
+ */
+
+
+/**
+  @addtogroup MatMultTrans
+  @{
+ */
+
+/**
+  @brief Glue code for parallel matrix mutliplication of 8-bit fix-point matrices.
+  @param[in]  pSrcA     points to the first input matrix
+  @param[in]  pSrcB     points to the second input matrix, stored transposed in memory
+  @param[in]  M         height of the first input matrix
+  @param[in]  N         width of the first input matrix and hight of the second
+  @param[in]  O         width of the second input matrix
+  @param[in]  shift     Amount to shift the result of each multiplication.
+  @param[in]  nPE       Number of cores to use
+  @param[out] pDstC     points to the output matrix
+  @return        none
+
+  @par Fix-Point and Shifting
+  The result will be shifted by the parameter `shift` to the right (multiplied
+  by 2^-shift). Assume that matrix A is represented as pSrcA * 2^-x, and matrix
+  B as pSrcB * 2^-y (in other words, A has it's x last digits after the binary
+  point). Then, the output is represented as pDstC * 2^-(x + y - shift).
+
+  The output of the matrix multiplication will also be stored as an 8-bit array.
+  Set the `shift` parameter such that no overflow ocurrs.
+ */
+
+void plp_mat_mult_trans_q8_parallel(const int8_t * __restrict__ pSrcA,
+                                    const int8_t * __restrict__ pSrcB,
+                                    uint32_t M,
+                                    uint32_t N,
+                                    uint32_t O,
+                                    uint32_t shift,
+                                    uint32_t nPE,
+                                    int8_t * __restrict__ pDstC){
+  
+  if (rt_cluster_id() == ARCHI_FC_CID){
+    printf("parallel processing supported only for cluster side\n");
+    return;
+  }
+  else{
+    plp_mat_mult_instance_q8 args = {
+      .pSrcA = pSrcA,
+      .pSrcB = pSrcB,
+      .M = M,
+      .N = N,
+      .O = O,
+      .shift = shift,
+      .nPE = nPE,
+      .pDstC = pDstC
+    };
+    rt_team_fork(nPE,plp_mat_mult_trans_q8vp_xpulpv2, (void*) &args);
+  }
+
+}
+
+/**
+  @} end of MatMultTrans group
+ */
+
+

--- a/test/README.md
+++ b/test/README.md
@@ -19,57 +19,199 @@ New tests can be generated using the test_template located at `test/mrWolf/test_
 1. Copy and rename the folder `test/mrWolf/test_template` to `test/mrWolf/[NAME]`. The two necessary files in this folder are: `testset.cfg` and `gen_stimuli.py`.
 2. Edit `test/mrWolf/testset.cfg` and add the new test using `add_test_folder`.
 3. Edit the `testset.cfg` configuration file (which is treated as a regular python sctipt):
-   1. Create the `variables` list. Add one or more `SweepVariable`s, and tests will be created for each combination. This is usually used to generate multiple tests with different dimensionality of the input vectors. However, this is not always enough. As an example, if the output vector has a different length than all input vectors (as it is the case for convolution or matrix multiplication), then you can use `DynamicVariables`, which require a function `f(env: dict) -> val` as an argument. The environment `env` is a dictionary, mapping other variables (`SweeiVariable`s) to their value. See the testcase `test/mrWolf/conv/test_lib/ibex/testset.cfg` as an example.
-   2. Create the `arguments` list. The order must be the same as defined in the function declaration. However, the names are used internally, and don't need to match. For all arguments, the parameter `use_l1` is only considered for riscy testcases, and is ignored when the ibex core is used. You can use the following argument types:
-      - `Argument`: basic argument, representing a single value like an integer or a float. The Constructor takes:
-        - `name`: the name used internally, can be chosen arbitrarily (as long as it is unique).
-        - `c_type`: either a valid type of `C`, including `stdint.h` or the string `var_type`, in which case the type will be chosen based on the `version`, e.g., `i32` will cause the `var_type` to be replaced with `int32_t`.
-        - `value`: either use a specific value, the name of a `Variable` (as defined in the `variables` list) or `None` (the framework will then choose a random value).
-        - `use_l1`: Boolean or None. if None, use the default configuration (as specified `generate_test`, see below).
-      - `ArrayArgument`: array argument, which is passed to the funciton as a pointer. 
-        - `name`: the name used internally, can be chosen arbitrarily (as long as it is unique).
-        - `c_type`: either a valid type of `C`, including `stdint.h` or the string `var_type`, in which case the type will be chosen based on the `version`, e.g., `i32` will cause the `var_type` to be replaced with `int32_t`. This type refers to the data type that is referenced. 
-        - `length`: either a specific size, the name of a `Variable` or a `tuple`: `(min, max)`, in which case a random value in this range will be chosen.
-        - `value`: either a list of values (must then have the same length as the `length` argument), a single value (in which case all elements will be initialized with this value), a `tuple`: `(min, max)` where a random value will be chosen in the specified range, or `None`, in which case the entire range available in `c_type` will be used.
-        - `use_l1`: Boolean or None. if None, use the default configuration (as specified `generate_test`, see below).
-      - `FixPointArgument`: argument which is only used for the fix-point implementation. This field must specify the position of the binary point. The constructor has identical arguments as `Argument`, but it uses `ctype=uint32_t` by default.
-      - `ParallelArgument`: argument which is only used for the parallel implementation. This field must specify the number of processing units (cores). The constructor has identical arguments as `Argument`, but it uses `ctype=uint32_t` by default.
-      - `OutputArgument`: array argument which represents the output array. Its constructor has the same arguments as `ArrayArgument`, however, without the parameter `value`, and with a `tolerance`:
-        - `name`: the name used internally, can be chosen arbitrarily (as long as it is unique).
-        - `c_type`: either a valid type of `C`, including `stdint.h` or the string `var_type`, in which case the type will be chosen based on the `version`, e.g., `i32` will cause the `var_type` to be replaced with `int32_t`. This type refers to the data type that is referenced.
-        - `length`: either a specific size, the name of a `Variable` or a `tuple`: `(min, max)`, in which case a random value in this range will be chosen.
-        - `tolerance`: Either a value (default 0) or a function, which maps the version string to the relative tolerance. The tolerance check is only enabled if the parameter for a given version is nonzero.
-        - `use_l1`: Boolean or None. if None, use the default configuration (as specified `generate_test`, see below).
-      - `ReturnValue`: return value of the function. Obviously, there can only ever exist one `ReturnValue` in the `arguments` list. The constructor needs the following arguments:
-        - `c_type`: either a valid type of `C`, including `stdint.h` or the string `var_type`, in which case the type will be chosen based on the `version`, e.g., `i32` will cause the `var_type` to be replaced with `int32_t`.
-        - `tolerance`: Either a value (default 0) or a function, which maps the version string to the relative tolerance. The tolerance check is only enabled if the parameter for a given version is nonzero.
-        - `use_l1`: Boolean or None. if None, use the default configuration (as specified `generate_test`, see below).
-   3. Edit the `implemented` dictionary. This `dict` maps the device name (either `'ibex'` or `'riscy'`) to the version-`dict`, which maps the version name (like `i32` and `q8`) to a boolean, Only versions which map to `True` will be tested. The `c_type` `var_type` and `ret_type` is dependent on this version. Additionally, the suffix `_parallel` can be used to enable tests for the parallel implementation.
-   4. Create the function `n_ops`. This function `n_ops(env: dict) -> int` takes the environment `env` as an argument, which is defined identical as for `DynamicVariables`, see above. It should return the number of operations in an ideal setting (used for benchmarking only).
-   5. (Optional) Create a dictionary `arg_ret_type`, which maps the version name (without any extension like `_parallel`) to a tuple of two strings, where the first string is the c type for the input arguments (`var_type` used for argument description), and the second one is the c type for the return type (`ret_type` used for argument description). Any version which is not present in this dictionary will take the follwing default values:
-      | version | `var_type` | `ret_type` |
-      | ------- | ---------- | ---------- |
-      | `i8`    | `int8_t`   | `int32_t`  |
-      | `i16`   | `int16_t`  | `int32_t`  |
-      | `i32`   | `int32_t`  | `int32_t`  |
-      | `q8`    | `int8_t`   | `int32_t`  |
-      | `q16`   | `int16_t`  | `int32_t`  |
-      | `q32`   | `int32_t`  | `int32_t`  |
-      | `f32`   | `float`    | `float`    |
-   6. Call `generate_test` and store the returned struct as `TestConfig`. This function takes the following arguments:
-      - `function_name: str`: name of the function without the version
-      - `arguments: list`: see above
-      - `variables: list`: see above
-      - `implemented: dict`: see above
-      - `use_l1: bool`: default value for `use_l1` for all arguments. This can be overwritten for individual arguments.
-      - `extended_output: bool`: if `True`, all errors will be printed to stdout, can be used for debugging.
-      - `n_macs`: function (see above). If not given, the benchmark will assume that it has 0 macs.
-3. Edit the `gen_stimuli.py` script, and write the function `compute_result`, which represents the Golden Model. This function takes four parameters:
-   - `result_parameter`: This is either `OutputArgument` or `ReturnValue`, which tells the function what expected output to generate. This argument has all ambiguity removed, and is instantiated based on the current sweep, which means that `c_type` and `length` are set to a specific type and length. The function `compute_result` will be called multiple times, for each `OutputArgument` or `ReturnValue` that was specified in the `arguments` list.
-   - `inputs` This is a dictionary, which maps the name of all arguments to one of the `Argument` object. As for the `result_parameter`, the argument is instantiated properly, and the `c_type`, the `length` and the `value` have specific values, and can be used to generate the result. All `OutputArguments` and the `ReturnValue` are missing in this dictionary.
-   - `env`: Environment dictionary, which maps the variable names (defined in the `testset.cfg`) to their value of the current test.
-   - `fix_point`: Either `False` (for no use of fix-point) or the position of the binary point.
-   The function must return a list (or numpy array) with the expected result (or a single value in case of `ReturnValue`).
+   1. Create the [`variables`](#variables) list.
+   2. Create the [`arguments`](#arguments) list. The following arguments are possible
+      - [`Argument`](#default-argument)
+      - [`ArrayArgument`](#arrayargument)
+      - [`FixPointArgument`](#fixpointargument)
+      - [`ParallelArgument`](#parallelargument)
+      - [`OutputArgument`](#outputargument)
+      - [`ReturnValue`](#returnvalue)
+   3. Edit the [`implemented` dictionary](#generate_test).
+   4. Create the function [`n_ops`](#generate_test).
+   5. (Optional) Create a dictionary [`arg_ret_type`](#generate_test).
+   6. Call [`generate_test`](#generate_test) and store the returned struct as `TestConfig`
+3. Edit the `gen_stimuli.py` script, and write the function [`compute_result`](#compute_result) (and optionally [`generate_stimuli`](#generate_stimuli))
+
+### testset.cfg
+
+This file calls the test framework with the correct configuration. It is interpreted as a regular python script. The last line calls `generate_test`:
+
+#### generate_test
+
+This is the main funciton which generates the setset (required for [plptest](https://github.com/pulp-platform/plptest)). It returns a testset structure, which *must* be assigned to a variable called `TestConfig`. This function has the following arguments:
+
+- `function_name`: Name of the function to be tested, without the version suffix (like `_q16`).
+- `arguments`: List of [`Argument`s](#arguments)
+- `variables`: List of [`Variable`s](#variables)
+- `implemented`: Dictionary, which has the following structure (the first dictionary must always contain the keys `'riscy'` and `'ibex'`!):
+  ```
+  {
+    'riscy': {
+      'i8': True,
+      'i16': True,
+      #...
+      'i8_parallel': False,
+      #...
+    },
+    'ibex' :{
+      #...
+    }
+  }
+  ```
+- (optional) `use_l1`: Boolean, default value for using L1 scratchpad memory for the arrays or not. For IBEX test cases, L2 is always used. This value can be overwritten for every `Argument` individually.
+- (optional) `extended_output`: Boolean. If `True`, the test will print out all mistakes (their position, the expected value and the acquired result). This should be disabled when running on a board!
+- (optional) `n_ops`: Funciton, which maps the current `version` (from `implemented`) to a number of ops. This is used for bechmarking.
+- (optional) `arg_ret_type`: Dictionary, which maps the `version` to the ctype, which is used for `arg_type` and `ret_type` in the `Variable`s. It has the following form:
+  ```
+  {
+	'i32':   ('int32_t', 'int32_t'),
+	'i16':   ('int16_t', 'int16_t'),
+    #...
+  }
+  ```
+  If a version is not present in this dictionary, the following default values are used:
+  | version | `var_type` | `ret_type` |
+  | ------- | ---------- | ---------- |
+  | `i8`    | `int8_t`   | `int32_t`  |
+  | `i16`   | `int16_t`  | `int32_t`  |
+  | `i32`   | `int32_t`  | `int32_t`  |
+  | `q8`    | `int8_t`   | `int32_t`  |
+  | `q16`   | `int16_t`  | `int32_t`  |
+  | `q32`   | `int32_t`  | `int32_t`  |
+  | `f32`   | `float`    | `float`    |
+
+#### Variables
+
+Variables are used to sweep over multiple different test instances (e.g. dimensions). There are two different variable types:
+
+##### SweepVariable
+
+These variables are used to define the sweeps. It's constructor has the following arguments:
+
+- `name`: Name for the variable, which can be used later for [`Argument`s](#arguments)
+- `values`: List (or other iterable) over all values to be swept.
+- (optional) `visible`: Boolean. If `True`, this variable will appear in the test name. If `False`, the variable is hidden.
+
+##### DynamicVariable
+
+If there are other parameters, which depend on `SweepVariable`s, but are different, then you can use `DynamicVariable`. You can specify a function based in previously defined `Variable`s (in the `variables` list).
+
+- `name`: Name for the variable, which can be used later for [`Argument`s](#arguments)
+- `fun`: function: `F: dict(str, number) -> number`, which maps the environment (previous `Arguments`) to a value.
+- (optional) `visible`: Boolean. If `True`, this variable will appear in the test name. If `False`, the variable is hidden.
+
+#### Arguments
+
+With arguments, you describe how the function, which is tested, looks like. There are several different argument types:
+
+##### Default Argument
+
+This argument represents a single scalar argument for the function. It's constructor has the following parameters:
+
+- `name`: Name of the argument. This is only used internally, and does not need to match the one from the function declaration.
+- `ctype`: String, representing the type in `C` to be used (like `int16_t`). If the type is dependent on the `version`, you can use either the string `var_type` or `ret_type` (see [`generate_test`](#generate_test)).
+- `value`: This is the value which should be used: It can be one of the following:
+  - Number for constant initialization
+  - The name of a `SweepVariable` or `DynamicVariable`, to take their value for the current iteration.
+  - None for a random value
+  - Tuple `(min, max)` for a random value in the given range
+  - The string `"gen_stimuli"` (or the constant `pulp_dsp_test.GENERATE_STIMULI`). in this case, the values can be computed in the [`generate_stimuli` function](#generate_stimuli)
+- (optional) `use_l1`: Boolean to tell if L1 storage should be used. This overwrites the argument in [`generate_test`](#generate_test).
+
+##### ArrayArgument
+
+This argument represents an array argument for the function, which is passed via a pointer. It's constructor has the following parameters:
+
+- `name`: Name of the argument. This is only used internally, and does not need to match the one from the function declaration.
+- `ctype`: String, representing the type in `C` to be used (like `int16_t`). If the type is dependent on the `version`, you can use either the string `var_type` or `ret_type` (see [`generate_test`](#generate_test)).
+- `length`: This represents the length of the array. It can be one of the following:
+  - Number for a constant-sized array
+  - The name of a `SweepVariable` or `DynamicVariable` to set the length to the value of this variable at the current iteration.
+  - Tuple `(min, max)` for a random length.
+- `value`: This is the value which should be used: It can be one of the following:
+  - Number for constant initialization, where all elements of the array will have this value,
+  - `np.ndarray` to set the array to this constant value (the length must match!)
+  - None for a random value
+  - Tuple `(min, max)` for a random value in the given range
+  - The string `"gen_stimuli"` (or the constant `pulp_dsp_test.GENERATE_STIMULI`). in this case, the values can be computed in the [`generate_stimuli` function](#generate_stimuli)
+- (optional) `use_l1`: Boolean to tell if L1 storage should be used. This overwrites the argument in [`generate_test`](#generate_test).
+
+##### OutputArgument
+
+This argument represents an array, to which the function writes the result. A funciton declaration can have multiple `OutputArgument`. This argument is passed to the function as a pointer. The constructor has the following parameters:
+
+- `name`: Name of the argument. This is only used internally, and does not need to match the one from the function declaration.
+- `ctype`: String, representing the type in `C` to be used (like `int16_t`). If the type is dependent on the `version`, you can use either the string `var_type` or `ret_type` (see [`generate_test`](#generate_test)).
+- `length`: This represents the length of the array. It can be one of the following:
+  - Number for a constant-sized array
+  - The name of a `SweepVariable` or `DynamicVariable` to set the length to the value of this variable at the current iteration.
+  - Tuple `(min, max)` for a random length.
+- (optional) `use_l1`: Boolean to tell if L1 storage should be used. This overwrites the argument in [`generate_test`](#generate_test).
+- (optional) `tolerance`: Constant number (`float`) or a funciton, which maps the current `version` (without the `_parallel` suffix) to a float value representing the *relative tolerance*. The tolerance is respected for both integer type arrays and floating-point arrays.
+
+The expected output must be computed in the [`compute_result` function](#compute_result). The test framework will automatically generate a test to check that every element matches the expected result.
+
+##### ReturnValue
+
+This represents the value, which is returned by the function. If nothing is returned by the function, then this argument cannot be used!. The constructor has the following parameters:
+
+- `name`: Name of the argument. This is only used internally, and does not need to match the one from the function declaration.
+- `ctype`: String, representing the type in `C` to be used (like `int16_t`). If the type is dependent on the `version`, you can use either the string `var_type` or `ret_type` (see [`generate_test`](#generate_test)).
+- (optional) `use_l1`: Boolean to tell if L1 storage should be used. This overwrites the argument in [`generate_test`](#generate_test).
+- (optional) `tolerance`: Constant number (`float`) or a funciton, which maps the current `version` (without the `_parallel` suffix) to a float value representing the *relative tolerance*. The tolerance is respected for both integer type arrays and floating-point arrays.
+
+The expected output must be computed in the [`compute_result` function](#compute_result). The test framework will automatically generate a test to check that every element matches the expected result.
+
+##### FixPointArgument
+
+This is very similar to the [default `Argument`](#default-argument), but it represents the fix-point position used in the computation. This argument is only added to the test for fix-point versions. And if fix-point versions are used, exactly one `FixPointArgument` is required. The `ctype` is always assumed to be `uint32_t`. It has the following arguments:
+
+- `name`: Name of the argument. This is only used internally, and does not need to match the one from the function declaration.
+- `value`: This is the value which should be used: It can be one of the following:
+  - Number for constant initialization
+  - The name of a `SweepVariable` or `DynamicVariable`, to take their value for the current iteration.
+  - None for a random value
+  - Tuple `(min, max)` for a random value in the given range
+  - The string `"gen_stimuli"` (or the constant `pulp_dsp_test.GENERATE_STIMULI`). in this case, the values can be computed in the [`generate_stimuli` function](#generate_stimuli)
+- (optional) `use_l1`: Boolean to tell if L1 storage should be used. This overwrites the argument in [`generate_test`](#generate_test).
+
+##### ParallelArgument
+
+This is very similar to the [default `Argument`](#default-argument), but it represents the number of processor cores used in the parallel version. This argument is only added to the test for parallel versions. And if parallel versions are used, exactly one `ParallelArgument` is required. The `ctype` is always assumed to be `uint32_t`. It has the following arguments:
+
+- `name`: Name of the argument. This is only used internally, and does not need to match the one from the function declaration.
+- `value`: This is the value which should be used: It can be one of the following:
+  - Number for constant initialization
+  - The name of a `SweepVariable` or `DynamicVariable`, to take their value for the current iteration.
+  - None for a random value
+  - Tuple `(min, max)` for a random value in the given range
+  - The string `"gen_stimuli"` (or the constant `pulp_dsp_test.GENERATE_STIMULI`). in this case, the values can be computed in the [`generate_stimuli` function](#generate_stimuli)
+- (optional) `use_l1`: Boolean to tell if L1 storage should be used. This overwrites the argument in [`generate_test`](#generate_test).
+
+### gen_stimuli.py
+
+This file contains the functions for generating the stimuli and the expected result.
+
+#### compute_result
+
+This function (with the exact name `compute_result`) computes the result of one output (either [`OutputArgument`](#outputargument) or [`ReturnValue`](#returnvalue)). If there are multiple such arguments defined in [`testset.cfg`](#testset.cfg), then this function is called multiple times, with different parameters. The function must take the following arguments:
+
+- `result_parameter`: Either [`OutputArgument`](#outputargument) or [`ReturnValue`](#returnvalue), the one for which the result must be computed. You can use `result_parameter.name`, `result_parameter.ctype` or `result_parameter.length` to write the function.
+- `inputs`: A list of [`Argument`s](#arguments). Use `inputs[i].value` to get the stimuli for the function.
+- `env`: A dictionary, which maps the [`Variable`](#variables) name to a value.
+- `fix_point`: Either `None` if fix_point is not used, or the specific positoin of the fix-point for this iteration.
+
+This function *must* return the `np.ndarray` with the expected result.
+
+#### generate_stimuli
+
+This optional function (with the exact name `generate_stimuli`) will generate the stimuli vector (or scalar) for [`Argument`s](#default-argument) or [`ArrayArgument`s](#arrayargument), for which the `value` is set to `'gen_stimuli'`. This function can be called multiple times, for each of these arguments once. It takes in the following arguments:
+
+- `argument`: Either [`Argument`s](#default-argument) or [`ArrayArgument`s](#arrayargument) for which the stimuli need to be generated. Use `argument.name`, `argument.ctype` and `argument.length` to write this function.
+- `env`: A dictionary, which maps the [`Variable`](#variables) name to a value.
+
+This function *must* return the `np.ndarray` with the expected result.
 
 ## Usage
 

--- a/test/mrWolf/mat_mul_trans/test_lib/gen_stimuli.py
+++ b/test/mrWolf/mat_mul_trans/test_lib/gen_stimuli.py
@@ -19,15 +19,33 @@ def compute_result(result_parameter, inputs, env, fix_point):
     env: Dict mapping the variable (SweepVariable or DynamicVariable) names to their value.
     fix_point: None (if no fixpoint is used) or decimal point
     """
-    if result_parameter.ctype == 'int32_t':
+    if fix_point is not None:
+        # fix-point computation
         a = inputs['srcA'].value.astype(np.int32).reshape((env['len_m'], env['len_n']))
         b = inputs['srcB'].value.astype(np.int32).reshape((env['len_o'], env['len_n']))
-        if fix_point is None or fix_point == 0:
-            result = np.matmul(a, b.T).astype(np.int32).reshape((env['len_res'], ))
-        else:
-            raise RuntimeError("Fix-Point not implemented")
+        ctype = result_parameter.ctype
+        dtype = np.int8 if ctype == "int8_t" else np.int16 if ctype == "int16_t" else np.int32
+        result = np.zeros((env['len_m'], env['len_o']), dtype=dtype)
+        for m in range(env['len_m']):
+            for o in range(env['len_o']):
+                s = np.int32(0)
+                for n in range(env['len_n']):
+                    s += q_roundnorm(a[m, n] * b[o, n], fix_point)
+                result[m, o] = dtype(s)
+        result = result.reshape((env['len_res'], ))
+    elif result_parameter.ctype == 'int32_t':
+        a = inputs['srcA'].value.astype(np.int32).reshape((env['len_m'], env['len_n']))
+        b = inputs['srcB'].value.astype(np.int32).reshape((env['len_o'], env['len_n']))
+        result = np.matmul(a, b.T).astype(np.int32).reshape((env['len_res'], ))
     elif result_parameter.ctype == 'float':
-        raise RuntimeError("Float not implemented")
+        a = inputs['srcA'].value.astype(np.float32).reshape((env['len_m'], env['len_n']))
+        b = inputs['srcB'].value.astype(np.float32).reshape((env['len_o'], env['len_n']))
+        result = np.zeros((env['len_m'], env['len_o']), dtype=np.float32)
+        for m in range(env['len_m']):
+            for o in range(env['len_o']):
+                for n in range(env['len_n']):
+                    result[m, o] = np.float32(result[m, o] + np.float32(a[m, n] * b[o, n]))
+        result = result.reshape((env['len_res'], ))
     else:
         raise RuntimeError("Unrecognized result type: %s" % result_parameter.ctype)
 

--- a/test/mrWolf/mat_mul_trans/test_lib/testset.cfg
+++ b/test/mrWolf/mat_mul_trans/test_lib/testset.cfg
@@ -76,8 +76,9 @@ arguments = [
 	Argument('len_m', 'uint32_t', 'len_m'),
 	Argument('len_n', 'uint32_t', 'len_n'),
 	Argument('len_o', 'uint32_t', 'len_o'),
+	FixPointArgument('shift', 4),
 	ParallelArgument('nPe', 8),
-	OutputArgument('pRes', 'ret_type', 'len_res'),
+	OutputArgument('pRes', 'ret_type', 'len_res', tolerance=lambda v: 1e-2 if v.startswith('f') else 1e-2 if v.startswith('q') else 0),
 ]
 
 implemented = {
@@ -85,28 +86,38 @@ implemented = {
 		'i32': True,
 		'i16': True,
 		'i8':  True,
-		'q32': False,
-		'q16': False,
-		'q8':  False,
-		'f32': False,
+		'q32': True,
+		'q16': True,
+		'q8':  True,
+		'f32': True,
 		'i32_parallel': True,
 		'i16_parallel': True,
 		'i8_parallel':  True,
-		'q32_parallel': False,
-		'q16_parallel': False,
-		'q8_parallel':  False,
-		'f32_parallel': False
+		'q32_parallel': True,
+		'q16_parallel': True,
+		'q8_parallel':  True,
+		'f32_parallel': True
 	},
 	'ibex': {
 		'i32': True,
 		'i16': True,
 		'i8':  True,
-		'q32': False,
-		'q16': False,
-		'q8':  False,
+		'q32': True,
+		'q16': True,
+		'q8':  True,
 	}
 }
 
 n_ops = lambda env: env['len_m'] * env['len_n'] * env['len_o']
 
-TestConfig = c = generate_test(function_name, arguments, variables, implemented, use_l1=True, n_ops=n_ops)
+arg_ret_type = {
+	'i32':   ('int32_t', 'int32_t'),
+	'i16':   ('int16_t', 'int32_t'),
+	'i8':    ('int8_t',  'int32_t'),
+	'q32':   ('int32_t', 'int32_t'),
+	'q16':   ('int16_t', 'int16_t'),
+	'q8':    ('int8_t',  'int8_t'),
+    'float': ('float',   'float')
+}
+
+TestConfig = c = generate_test(function_name, arguments, variables, implemented, use_l1=True, n_ops=n_ops, arg_ret_type=arg_ret_type)

--- a/test/mrWolf/test_template/test_lib/gen_stimuli.py
+++ b/test/mrWolf/test_template/test_lib/gen_stimuli.py
@@ -3,6 +3,28 @@
 import numpy as np
 
 
+####################
+# generate_stimuli #
+####################
+
+
+def generate_stimuli(arg, env):
+    """
+    Function to generate the stimuli
+
+    Arguments
+    ---------
+    arg: Argument for which to generate stimuli (either Argument or ArrayArgument)
+    env: Dict mapping the variable (SweepVariable or DynamicVariable) names to their value.
+    """
+    # name = arg.name
+    # if name == "srcA":
+    #     # generate and return stimuli for srcA
+    # if name == "srcB":
+    #     # generate and return stimuli for srcB
+    # ...
+
+
 ##################
 # compute_result #
 ##################
@@ -39,7 +61,7 @@ def compute_result(result_parameter, inputs, env, fix_point):
             for i in range((len(a) // groups) * groups, len(a)):
                 result[0] = q_add(result[0], q_roundnorm(a[i] * b[i], fix_point))
     elif result_parameter.ctype == 'float':
-        # for float implementation, it is important to always use float32 for intermediate operations!
+        # for float implementation, it is important to always use float32 for intermediate ops!
         a = inputs['srcA'].value.astype(np.float32)
         b = inputs['srcB'].value.astype(np.float32)
         res = np.float32(0)

--- a/test/mrWolf/test_template/test_lib/testset.cfg
+++ b/test/mrWolf/test_template/test_lib/testset.cfg
@@ -113,4 +113,4 @@ arg_ret_type = {
     'float': ('float',   'float')
 }
 
-TestConfig = c = generate_test(function_name, arguments, variables, implemented, use_l1=True, n_macs=n_macs, arg_ret_type=arg_ret_type)
+TestConfig = c = generate_test(function_name, arguments, variables, implemented, use_l1=True, n_ops=n_ops, arg_ret_type=arg_ret_type)


### PR DESCRIPTION
# Test Framework:
- Added `generate_stimuli` function to `gen_stimuli.py`. This can be used when setting the value of a variable to `'gen_stimuli'`
- Rewrote `README.md` with all the new changes. Should now be much more complete, and better usable.

# DSP library
- Extended `mat_mult_trans` with all missing funcitons