### PR TITLE
dot_prod fixed, testcases updated

### DIFF
--- a/src/BasicMathFunctions/dot_prod/kernels/plp_dot_prod_q16s_rv32im.c
+++ b/src/BasicMathFunctions/dot_prod/kernels/plp_dot_prod_q16s_rv32im.c
@@ -68,23 +68,27 @@ void plp_dot_prod_q16s_rv32im(const int16_t *__restrict__ pSrcA,
     uint32_t blkCnt; /* Loop counter */
     int32_t sum = 0; /* Temporary return variable */
 
+    int32_t bias = 1 << (deciPoint - 1);
+
 #if defined(PLP_MATH_LOOPUNROLL)
 
     for (blkCnt = 0; blkCnt < (blockSize >> 2); blkCnt++) {
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
+        int32_t tmp;
+        tmp = (*pSrcA++) * (*pSrcB++);
+        tmp += (*pSrcA++) * (*pSrcB++);
+        tmp += (*pSrcA++) * (*pSrcB++);
+        tmp += (*pSrcA++) * (*pSrcB++);
+        sum += (tmp + bias) >> deciPoint;
     }
 
     for (blkCnt = 0; blkCnt < (blockSize % 4U); blkCnt++) {
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
+        sum += (((*pSrcA++) * (*pSrcB++)) + bias) >> deciPoint;
     }
 
 #else // PLP_MATH_LOOPUNROLL
 
     for (blkCnt = 0; blkCnt < blockSize; blkCnt++) {
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
+        sum += (((*pSrcA++) * (*pSrcB++)) + bias) >> deciPoint;
     }
 
 #endif // PLP_MATH_LOOPUNROLL

--- a/src/BasicMathFunctions/dot_prod/kernels/plp_dot_prod_q32p_xpulpv2.c
+++ b/src/BasicMathFunctions/dot_prod/kernels/plp_dot_prod_q32p_xpulpv2.c
@@ -84,6 +84,11 @@ void plp_dot_prod_q32p_xpulpv2(void *S) {
         blkSize = blkSizePE - (nPE - 1) * blkSize;
     }
 
+    if (blkSize == 0) {
+        *resBufferPE = 0;
+        return;
+    }
+
     int32_t i, sum = 0;
 
 #if defined(PLP_MATH_LOOPUNROLL)

--- a/src/BasicMathFunctions/dot_prod/kernels/plp_dot_prod_q32s_rv32im.c
+++ b/src/BasicMathFunctions/dot_prod/kernels/plp_dot_prod_q32s_rv32im.c
@@ -63,23 +63,25 @@ void plp_dot_prod_q32s_rv32im(const int32_t *__restrict__ pSrcA,
     uint32_t blkCnt; /* Loop counter */
     int32_t sum = 0; /* Temporary return variable */
 
+    int32_t bias = 1 << (deciPoint - 1);
+
 #if defined(PLP_MATH_LOOPUNROLL)
 
-    for (blkCnt = 0; blkCnt < (blockSize >> 2); blkCnt++) {
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
+    for (blkCnt = 0; blkCnt < (blockSize >> 1); blkCnt++) {
+        int32_t tmp;
+        tmp = (*pSrcA++) * (*pSrcB++);
+        tmp += (*pSrcA++) * (*pSrcB++);
+        sum += (tmp + bias) >> deciPoint;
     }
 
-    for (blkCnt = 0; blkCnt < (blockSize % 4U); blkCnt++) {
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
+    for (blkCnt = 0; blkCnt < (blockSize % 2U); blkCnt++) {
+        sum += (((*pSrcA++) * (*pSrcB++)) + bias) >> deciPoint;
     }
 
 #else // PLP_MATH_LOOPUNROLL
 
     for (blkCnt = 0; blkCnt < blockSize; blkCnt++) {
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
+        sum += (((*pSrcA++) * (*pSrcB++)) + bias) >> deciPoint;
     }
 
 #endif // PLP_MATH_LOOPUNROLL

--- a/src/BasicMathFunctions/dot_prod/kernels/plp_dot_prod_q8s_rv32im.c
+++ b/src/BasicMathFunctions/dot_prod/kernels/plp_dot_prod_q8s_rv32im.c
@@ -68,23 +68,31 @@ void plp_dot_prod_q8s_rv32im(const int8_t *__restrict__ pSrcA,
     uint32_t blkCnt; /* Loop counter */
     int32_t sum = 0; /* Temporary return variable */
 
+    int32_t bias = 1 << (deciPoint - 1);
+
 #if defined(PLP_MATH_LOOPUNROLL)
 
-    for (blkCnt = 0; blkCnt < (blockSize >> 2); blkCnt++) {
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
+    for (blkCnt = 0; blkCnt < (blockSize >> 3); blkCnt++) {
+        int32_t tmp;
+        tmp = (*pSrcA++) * (*pSrcB++);
+        tmp += (*pSrcA++) * (*pSrcB++);
+        tmp += (*pSrcA++) * (*pSrcB++);
+        tmp += (*pSrcA++) * (*pSrcB++);
+        tmp += (*pSrcA++) * (*pSrcB++);
+        tmp += (*pSrcA++) * (*pSrcB++);
+        tmp += (*pSrcA++) * (*pSrcB++);
+        tmp += (*pSrcA++) * (*pSrcB++);
+        sum += (tmp + bias) >> deciPoint;
     }
 
-    for (blkCnt = 0; blkCnt < (blockSize % 4U); blkCnt++) {
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
+    for (blkCnt = 0; blkCnt < (blockSize % 8U); blkCnt++) {
+        sum += (((*pSrcA++) * (*pSrcB++)) + bias) >> deciPoint;
     }
 
 #else // PLP_MATH_LOOPUNROLL
 
     for (blkCnt = 0; blkCnt < blockSize; blkCnt++) {
-        sum += (*pSrcA++) * (*pSrcB++) >> deciPoint;
+        sum += (((*pSrcA++) * (*pSrcB++)) + bias) >> deciPoint;
     }
 
 #endif // PLP_MATH_LOOPUNROLL

--- a/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_i32p_xpulpv2.c
+++ b/src/MatrixFunctions/mat_mult_trans/kernels/plp_mat_mult_trans_i32p_xpulpv2.c
@@ -47,45 +47,10 @@
    @return     none
 */
 
-// define BASIC_VERSION // if used don't forget to also use the undefine at end of file
-
-#ifdef BASIC_VERSION
-
 void plp_mat_mult_trans_i32p_xpulpv2(void *args) {
-    plp_mat_mult_instance_i32 *arguments = (plp_mat_mult_instance_i32 *)args;
-    const int32_t *__restrict__ pSrcA = arguments->pSrcA;
-    const int32_t *__restrict__ pSrcB = arguments->pSrcB;
-    uint32_t M = arguments->M;
-    uint32_t N = arguments->N;
-    uint32_t O = arguments->O;
-    uint32_t nPE = arguments->nPE;
-    int32_t *__restrict__ pDstC = arguments->pDstC;
-
-    uint32_t i; // loop counter for M
-    uint32_t j; // loop counter for N
-    uint32_t k; // loop counter for O
 
     int core_id = rt_core_id();
-    int step = (M - 1 + nPE) / nPE;
-    uint32_t START = step * core_id;
-    uint32_t END = (core_id != nPE - 1) ? START + step : M;
 
-    for (i = START; i < END; i++) {
-        for (k = 0; k < M; k++) {
-            int32_t sum = 0;
-            for (j = 0; j < N; j++) {
-                sum = sum + pSrcA[i * N + j] * pSrcB[k * N + j];
-            }
-            pDstC[i * O + k] = sum;
-        }
-    }
-
-    rt_team_barrier();
-}
-
-#else
-
-void plp_mat_mult_trans_i32p_xpulpv2(void *args) {
     plp_mat_mult_instance_i32 *arguments = (plp_mat_mult_instance_i32 *)args;
     const int32_t *__restrict__ pSrcA = arguments->pSrcA;
     const int32_t *__restrict__ pSrcB = arguments->pSrcB;
@@ -94,141 +59,34 @@ void plp_mat_mult_trans_i32p_xpulpv2(void *args) {
     uint32_t O = arguments->O;
     uint32_t nPE = arguments->nPE;
     int32_t *__restrict__ pDstC = arguments->pDstC;
+
+#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+#ifdef BASIC_VERSION
 
     uint32_t m; // loop counter for M
     uint32_t n; // loop counter for N
     uint32_t o; // loop counter for O
 
-    int core_id = rt_core_id();
-
-    // first, to the major part of the computation:
-    // for (m = core_id * 2; m < M; m += nPE * 2) {
-    m = core_id * 2;
-    do {
-        // for (o = 0; o < O; o += 2) {
-        o = 0;
-        do {
-            int32_t sum_m0_o0 = 0;
-            int32_t sum_m0_o1 = 0;
-            int32_t sum_m1_o0 = 0;
-            int32_t sum_m1_o1 = 0;
-            // for (n = 0; n < N; n++) {
-            n = 0;
-            do {
-                // load all 4 values
-                int32_t a_m0 = pSrcA[m * N + n];
-                int32_t a_m1 = pSrcA[(m + 1) * N + n];
-                int32_t b_o0 = pSrcB[o * N + n];
-                int32_t b_o1 = pSrcB[(o + 1) * N + n];
-
-                // compute all 4 macs
-                sum_m0_o0 += a_m0 * b_o0;
-                sum_m0_o1 += a_m0 * b_o1;
-                sum_m1_o0 += a_m1 * b_o0;
-                sum_m1_o1 += a_m1 * b_o1;
-
-                n++;
-            } while (n < N);
-
-            // store the values
-            pDstC[m * O + o] = sum_m0_o0;
-            pDstC[m * O + o + 1] = sum_m0_o1;
-            pDstC[(m + 1) * O + o] = sum_m1_o0;
-            pDstC[(m + 1) * O + o + 1] = sum_m1_o1;
-
-            o += 2;
-        } while (o < O - 1);
-
-        m += nPE * 2;
-    } while (m < M - 1);
-
-    // clean up the odd O (o = O - 1)
-    if (O & 0x1) {
-        o = O - 1;
-        // loop over all m, unrolling two elements
-        // for (m = core_id * 2; m < M - 1; m += nPE * 2) {
-        m = core_id * 2;
-        do {
-            int32_t sum_m0 = 0;
-            int32_t sum_m1 = 0;
+    for (m = core_id; m < M; m += nPE) {
+        for (o = 0; o < O; o++) {
+            int32_t sum = 0;
             for (n = 0; n < N; n++) {
-                // load all 3values
-                int32_t b = pSrcB[o * N + n];
-                int32_t a_m0 = pSrcA[m * N + n];
-                int32_t a_m1 = pSrcA[(m + 1) * N + n];
-
-                // compute the two MACs
-                sum_m0 += a_m0 * b;
-                sum_m1 += a_m1 * b;
+                sum = sum + pSrcA[m * N + n] * pSrcB[o * N + n];
             }
-            pDstC[m * O + o] = sum_m0;
-            pDstC[(m + 1) * O + o] = sum_m1;
-
-            m += nPE * 2;
-        } while (m < M - 1);
-    }
-
-    // clean up the odd M (m = M - 1)
-    if (M & 0x1) {
-        m = M - 1;
-        // loop over all m, unrolling two elements
-        // for (o = core_id * 2; o < O - 1; o += nPE * 2) {
-        o = core_id * 2;
-        do {
-            int32_t sum_o0 = 0;
-            int32_t sum_o1 = 0;
-            for (n = 0; n < N; n++) {
-                // load all 3values
-                int32_t a = pSrcA[m * N + n];
-                int32_t b_o0 = pSrcB[o * N + n];
-                int32_t b_o1 = pSrcB[(o + 1) * N + n];
-
-                // compute the two MACs
-                sum_o0 += a * b_o0;
-                sum_o1 += a * b_o1;
-            }
-            pDstC[m * O + o] = sum_o0;
-            pDstC[m * O + o + 1] = sum_o1;
-
-            o += nPE * 2;
-        } while (o < O - 1);
-    }
-
-    // clean up the odd M and odd O (m = M - 1, o = O - 1)
-    if ((M & 0x1) && (O & 0x1) && core_id == nPE - 1) {
-        m = M - 1;
-        o = O - 1;
-        int32_t sum = 0;
-
-        // for (n = core_id * 2; n < N; n += nPE * 2) {
-        n = 0;
-        do {
-            int32_t a0 = pSrcA[m * N + n];
-            int32_t a1 = pSrcA[m * N + n + 1];
-            int32_t b0 = pSrcB[o * N + n];
-            int32_t b1 = pSrcB[o * N + n + 1];
-
-            // compute the dot product
-            sum += a0 * b0 + a1 * b1;
-
-            n += 2;
-        } while (n < N - 1);
-
-        // if N is odd, we need to add the last element to the sum
-        if (N & 0x1) {
-            // N is odd
-            n = N - 1;
-            sum += pSrcA[m * N + n] * pSrcB[o * N + n];
+            pDstC[m * O + o] = sum;
         }
-        pDstC[m * O + o] = sum;
     }
 
     rt_team_barrier();
-}
+
+#else
+
+    // TODO hackathon
 
 #endif
+#undef BASIC_VERSION
+}
 
-// undefine BASIC_VERSION
 /**
    @} end of MatMultTransKernels group
 */

--- a/test/README.md
+++ b/test/README.md
@@ -94,6 +94,7 @@ These variables are used to define the sweeps. It's constructor has the followin
 - `name`: Name for the variable, which can be used later for [`Argument`s](#arguments)
 - `values`: List (or other iterable) over all values to be swept.
 - (optional) `visible`: Boolean. If `True`, this variable will appear in the test name. If `False`, the variable is hidden.
+- (optional) `active`: Function: `F: version: str -> bool` which tells the test framework to use the sweep variable based on the current version.
 
 ##### DynamicVariable
 

--- a/test/mrWolf/dot_prod/test_lib/testset.cfg
+++ b/test/mrWolf/dot_prod/test_lib/testset.cfg
@@ -62,16 +62,17 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_dot_prod'
 
 variables = [
-	SweepVariable('len', [127, 128, 129, 130]),
+	SweepVariable('len', [2, 3, 127, 128, 129, 130, 258, 515]),
+	SweepVariable('deciPoint', [4, 5, 6], active=lambda v: 'q' in v)
 ]
 
 arguments = [
 	ArrayArgument('srcA', 'var_type', 'len', None),
 	ArrayArgument('srcB', 'var_type', 'len', None),
 	Argument('length', 'uint32_t', 'len'),
-	FixPointArgument('deciPoint', 4),
+	FixPointArgument('deciPoint', 'deciPoint'),
 	ParallelArgument('nPE', 8),
-	OutputArgument('res', 'ret_type', 1, tolerance=lambda v: 1e-2 if v.startswith('f') else 10 if v.startswith('q') else 0),
+	OutputArgument('res', 'ret_type', 1, tolerance=lambda v: 1e-2 if 'f' in v else 10 if 'q' in v else 0),
 ]
 
 implemented = {

--- a/test/mrWolf/mat_add/test_lib/testset.cfg
+++ b/test/mrWolf/mat_add/test_lib/testset.cfg
@@ -62,8 +62,8 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_add'
 
 variables = [
-	SweepVariable('len_m', [24, 25, 26, 27]),
-	SweepVariable('len_n', [24, 25, 26, 27]),
+	SweepVariable('len_m', [1, 24, 25, 26, 27]),
+	SweepVariable('len_n', [1, 24, 25, 26, 27]),
 	DynamicVariable('len', lambda env: env['len_m'] * env['len_n'], visible=False),
 ]
 

--- a/test/mrWolf/mat_add_stride/test_lib/testset.cfg
+++ b/test/mrWolf/mat_add_stride/test_lib/testset.cfg
@@ -62,8 +62,8 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_add_stride'
 
 variables = [
-	SweepVariable('len_m', [16, 17]),
-	SweepVariable('len_n', [15, 16, 17, 18]),
+	SweepVariable('len_m', [1, 16, 17]),
+	SweepVariable('len_n', [1, 15, 16, 17, 18]),
 	SweepVariable('lA', [0, 1], visible=False),
 	SweepVariable('lB', [0, 1], visible=False),
 	SweepVariable('lC', [0, 1], visible=False),

--- a/test/mrWolf/mat_mul/test_lib/testset.cfg
+++ b/test/mrWolf/mat_mul/test_lib/testset.cfg
@@ -62,9 +62,9 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_mult'
 
 variables = [
-	SweepVariable('len_m', [24, 25]),
-	SweepVariable('len_n', [24, 25, 26, 27]),
-	SweepVariable('len_o', [24, 25]),
+	SweepVariable('len_m', [1, 24, 25]),
+	SweepVariable('len_n', [1, 24, 25, 26, 27]),
+	SweepVariable('len_o', [1, 24, 25]),
 	DynamicVariable('len_srcA', lambda env: env['len_m'] * env['len_n'], visible=False),
 	DynamicVariable('len_srcB', lambda env: env['len_n'] * env['len_o'], visible=False),
 	DynamicVariable('len_res', lambda env: env['len_m'] * env['len_o'], visible=False),

--- a/test/mrWolf/mat_mul_cmplx/test_lib/testset.cfg
+++ b/test/mrWolf/mat_mul_cmplx/test_lib/testset.cfg
@@ -62,9 +62,9 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_mult_cmplx'
 
 variables = [
-	SweepVariable('len_m', [24, 25]),
-	SweepVariable('len_n', [24, 25, 26, 27]),
-	SweepVariable('len_o', [24, 25]),
+	SweepVariable('len_m', [1, 16, 17]),
+	SweepVariable('len_n', [1, 24, 25, 26, 27]),
+	SweepVariable('len_o', [1, 8, 9]),
 	DynamicVariable('len_srcA', lambda env: env['len_m'] * env['len_n'] * 2, visible=False),
 	DynamicVariable('len_srcB', lambda env: env['len_n'] * env['len_o'] * 2, visible=False),
 	DynamicVariable('len_res', lambda env: env['len_m'] * env['len_o'] * 2, visible=False),

--- a/test/mrWolf/mat_mul_cmplx_stride/test_lib/testset.cfg
+++ b/test/mrWolf/mat_mul_cmplx_stride/test_lib/testset.cfg
@@ -62,12 +62,12 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_mult_cmplx_stride'
 
 variables = [
-	SweepVariable('len_m', [16, 17]),
+	SweepVariable('len_m', [1, 16, 17]),
 	SweepVariable('len_n', [16, 17]),
-	SweepVariable('len_o', [8, 9]),
+	SweepVariable('len_o', [1, 8, 9]),
 	SweepVariable('lA', [0, 1], visible=False),
-	SweepVariable('lB', [0, 1], visible=False),
-	SweepVariable('lC', [0, 1], visible=False),
+	SweepVariable('lB', [1], visible=False),
+	SweepVariable('lC', [1], visible=False),
 	DynamicVariable('strideA', lambda e: e['len_n'] + e['lA']),
 	DynamicVariable('strideB', lambda e: e['len_o'] + e['lB']),
 	DynamicVariable('strideC', lambda e: e['len_o'] + e['lC']),

--- a/test/mrWolf/mat_mul_stride/test_lib/testset.cfg
+++ b/test/mrWolf/mat_mul_stride/test_lib/testset.cfg
@@ -62,11 +62,11 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_mult_stride'
 
 variables = [
-	SweepVariable('len_m', [16, 17]),
-	SweepVariable('len_n', [24, 25]),
-	SweepVariable('len_o', [12, 13]),
-	SweepVariable('lA', [0, 1], visible=False),
-	SweepVariable('lB', [0, 1], visible=False),
+	SweepVariable('len_m', [1, 16, 17]),
+	SweepVariable('len_n', [1, 24, 25]),
+	SweepVariable('len_o', [1, 8, 9]),
+	SweepVariable('lA', [1], visible=False),
+	SweepVariable('lB', [1], visible=False),
 	SweepVariable('lC', [0, 1], visible=False),
 	DynamicVariable('strideA', lambda e: e['len_n'] + e['lA']),
 	DynamicVariable('strideB', lambda e: e['len_o'] + e['lB']),

--- a/test/mrWolf/mat_mul_trans/test_lib/testset.cfg
+++ b/test/mrWolf/mat_mul_trans/test_lib/testset.cfg
@@ -62,9 +62,9 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_mult_trans'
 
 variables = [
-	SweepVariable('len_m', [24, 25]),
-	SweepVariable('len_n', [24, 25, 26, 27]),
-	SweepVariable('len_o', [24, 25]),
+	SweepVariable('len_m', [1, 16, 17]),
+	SweepVariable('len_n', [1, 24, 25, 26, 27]),
+	SweepVariable('len_o', [1, 8, 9]),
 	DynamicVariable('len_srcA', lambda env: env['len_m'] * env['len_n'], visible=False),
 	DynamicVariable('len_srcB', lambda env: env['len_n'] * env['len_o'], visible=False),
 	DynamicVariable('len_res', lambda env: env['len_m'] * env['len_o'], visible=False),
@@ -120,4 +120,4 @@ arg_ret_type = {
     'float': ('float',   'float')
 }
 
-TestConfig = c = generate_test(function_name, arguments, variables, implemented, use_l1=True, n_ops=n_ops, arg_ret_type=arg_ret_type)
+TestConfig = c = generate_test(function_name, arguments, variables, implemented, use_l1=True, n_ops=n_ops, arg_ret_type=arg_ret_type, extended_output=False)

--- a/test/mrWolf/mat_mul_trans_cmplx/test_lib/testset.cfg
+++ b/test/mrWolf/mat_mul_trans_cmplx/test_lib/testset.cfg
@@ -62,9 +62,9 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_mult_trans_cmplx'
 
 variables = [
-	SweepVariable('len_m', [24, 25]),
-	SweepVariable('len_n', [24, 25, 26, 27]),
-	SweepVariable('len_o', [24, 25]),
+	SweepVariable('len_m', [1, 16, 17]),
+	SweepVariable('len_n', [1, 24, 25, 26, 27]),
+	SweepVariable('len_o', [1, 8, 9]),
 	DynamicVariable('len_srcA', lambda env: env['len_m'] * env['len_n'] * 2, visible=False),
 	DynamicVariable('len_srcB', lambda env: env['len_o'] * env['len_n'] * 2, visible=False),
 	DynamicVariable('len_res', lambda env: env['len_m'] * env['len_o'] * 2, visible=False),

--- a/test/mrWolf/mat_mul_trans_cmplx_stride/test_lib/testset.cfg
+++ b/test/mrWolf/mat_mul_trans_cmplx_stride/test_lib/testset.cfg
@@ -62,12 +62,12 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_mult_trans_cmplx_stride'
 
 variables = [
-	SweepVariable('len_m', [16, 17]),
-	SweepVariable('len_n', [16, 17]),
-	SweepVariable('len_o', [8, 9]),
+	SweepVariable('len_m', [1, 16, 17]),
+	SweepVariable('len_n', [1, 24, 25]),
+	SweepVariable('len_o', [1, 8, 9]),
 	SweepVariable('lA', [0, 1], visible=False),
-	SweepVariable('lB', [0, 1], visible=False),
-	SweepVariable('lC', [0, 1], visible=False),
+	SweepVariable('lB', [1], visible=False),
+	SweepVariable('lC', [1], visible=False),
 	DynamicVariable('strideA', lambda e: e['len_n'] + e['lA']),
 	DynamicVariable('strideB', lambda e: e['len_n'] + e['lB']),
 	DynamicVariable('strideC', lambda e: e['len_o'] + e['lC']),

--- a/test/mrWolf/mat_mul_trans_stride/test_lib/testset.cfg
+++ b/test/mrWolf/mat_mul_trans_stride/test_lib/testset.cfg
@@ -62,11 +62,11 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_mult_trans_stride'
 
 variables = [
-	SweepVariable('len_m', [16, 17]),
-	SweepVariable('len_n', [24, 25]),
-	SweepVariable('len_o', [12, 13]),
+	SweepVariable('len_m', [1, 16, 17]),
+	SweepVariable('len_n', [1, 24, 25]),
+	SweepVariable('len_o', [1, 8, 9]),
 	SweepVariable('lA', [0, 1], visible=False),
-	SweepVariable('lB', [0, 1], visible=False),
+	SweepVariable('lB', [1], visible=False),
 	SweepVariable('lC', [0, 1], visible=False),
 	DynamicVariable('strideA', lambda e: e['len_n'] + e['lA']),
 	DynamicVariable('strideB', lambda e: e['len_n'] + e['lB']),

--- a/test/mrWolf/mat_scale/test_lib/testset_float.cfg
+++ b/test/mrWolf/mat_scale/test_lib/testset_float.cfg
@@ -62,8 +62,8 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_scale'
 
 variables = [
-	SweepVariable('len_m', [24, 25, 26, 27]),
-	SweepVariable('len_n', [24, 25, 26, 27]),
+	SweepVariable('len_m', [1, 24, 25, 26, 27]),
+	SweepVariable('len_n', [1, 24, 25, 26, 27]),
     DynamicVariable('len_mat', lambda env: env['len_m'] * env['len_n'])
 ]
 

--- a/test/mrWolf/mat_scale/test_lib/testset_int.cfg
+++ b/test/mrWolf/mat_scale/test_lib/testset_int.cfg
@@ -62,8 +62,8 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_scale'
 
 variables = [
-	SweepVariable('len_m', [24, 25, 26, 27]),
-	SweepVariable('len_n', [24, 25, 26, 27]),
+	SweepVariable('len_m', [1, 24, 25, 26, 27]),
+	SweepVariable('len_n', [1, 24, 25, 26, 27]),
     DynamicVariable('len_mat', lambda env: env['len_m'] * env['len_n'])
 ]
 

--- a/test/mrWolf/mat_scale_stride/test_lib/testset_float.cfg
+++ b/test/mrWolf/mat_scale_stride/test_lib/testset_float.cfg
@@ -62,10 +62,10 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_scale_stride'
 
 variables = [
-	SweepVariable('len_m', [16, 17, 18, 19]),
-	SweepVariable('len_n', [24, 25, 26, 27]),
+	SweepVariable('len_m', [1, 16, 17, 18, 19]),
+	SweepVariable('len_n', [1, 16, 17, 18, 19]),
 	SweepVariable('lSrc', [0, 1], visible=False),
-	SweepVariable('lDst', [0, 1], visible=False),
+	SweepVariable('lDst', [1, 2], visible=False),
 	DynamicVariable('strideSrc', lambda e: e['len_n'] + e['lSrc']),
 	DynamicVariable('strideDst', lambda e: e['len_n'] + e['lDst']),
 	DynamicVariable('len_src', lambda e: e['len_m'] * e['strideSrc'], visible=False),

--- a/test/mrWolf/mat_scale_stride/test_lib/testset_int.cfg
+++ b/test/mrWolf/mat_scale_stride/test_lib/testset_int.cfg
@@ -62,10 +62,10 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_scale_stride'
 
 variables = [
-	SweepVariable('len_m', [16, 17, 18, 19]),
-	SweepVariable('len_n', [24, 25, 26, 27]),
+	SweepVariable('len_m', [1, 16, 17, 18, 19]),
+	SweepVariable('len_n', [1, 16, 17, 18, 19]),
 	SweepVariable('lSrc', [0, 1], visible=False),
-	SweepVariable('lDst', [0, 1], visible=False),
+	SweepVariable('lDst', [1, 2], visible=False),
 	DynamicVariable('strideSrc', lambda e: e['len_n'] + e['lSrc']),
 	DynamicVariable('strideDst', lambda e: e['len_n'] + e['lDst']),
 	DynamicVariable('len_src', lambda e: e['len_m'] * e['strideSrc'], visible=False),

--- a/test/mrWolf/mat_sub/test_lib/testset.cfg
+++ b/test/mrWolf/mat_sub/test_lib/testset.cfg
@@ -62,8 +62,8 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_sub'
 
 variables = [
-	SweepVariable('len_m', [24, 25, 26, 27]),
-	SweepVariable('len_n', [24, 25, 26, 27]),
+	SweepVariable('len_m', [1, 24, 25, 26, 27]),
+	SweepVariable('len_n', [1, 24, 25, 26, 27]),
 	DynamicVariable('len', lambda env: env['len_m'] * env['len_n'], visible=False),
 ]
 

--- a/test/mrWolf/mat_sub_stride/test_lib/testset.cfg
+++ b/test/mrWolf/mat_sub_stride/test_lib/testset.cfg
@@ -62,8 +62,8 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_sub_stride'
 
 variables = [
-	SweepVariable('len_m', [16, 17]),
-	SweepVariable('len_n', [15, 16, 17, 18]),
+	SweepVariable('len_m', [1, 16, 17]),
+	SweepVariable('len_n', [1, 15, 16, 17, 18]),
 	SweepVariable('lA', [0, 1], visible=False),
 	SweepVariable('lB', [0, 1], visible=False),
 	SweepVariable('lC', [0, 1], visible=False),

--- a/test/mrWolf/mat_trans/test_lib/testset.cfg
+++ b/test/mrWolf/mat_trans/test_lib/testset.cfg
@@ -62,8 +62,8 @@ from pulp_dsp_test import generate_test
 function_name = 'plp_mat_trans'
 
 variables = [
-	SweepVariable('len_m', [24, 25, 26, 27]),
-	SweepVariable('len_n', [24, 25, 26, 27]),
+	SweepVariable('len_m', [1, 24, 25, 26, 27]),
+	SweepVariable('len_n', [1, 24, 25, 26, 27]),
 	DynamicVariable('len_mat', lambda e: e['len_m'] * e['len_n'], visible=False),
 ]
 

--- a/test/mrWolf/pulp_dsp_test.py
+++ b/test/mrWolf/pulp_dsp_test.py
@@ -865,7 +865,7 @@ class AggregatedTest(object):
                             Shell('run', 'make run %s %s' % (platform_str, flags)),
                             Check('check', check_output, test_obj=self)
                         ],
-                        timeout=20)
+                        timeout=40)
 
     def get_common_header_str(self):
         return dedent(
@@ -1077,7 +1077,7 @@ def check_output(config, output, test_obj):
         print("{} {}".format(status, ", ".join(["{}={}".format(k, case.env[k])
                                                 for k in test_obj.visible_env])))
         # print mismatches
-        if result['mismatches']:
+        if result['mismatches'] and test_obj.extended_output:
             print(indent("\n".join(result['mismatches']), "      "))
 
         bench_output(result, test_obj, case)


### PR DESCRIPTION
# Fixes
- fix-point `dot_prod` implementation on RV32IM
- parallel i32 `mat_mult_trans`

# updated test cases
- Added test cases for matrix operations with which vector-matrix and vector-vector operations are tested.

# Test Framework
- Added `active` argument to `SweepVariables` to enable them for a specific version (e.g. creating a sweep over `fracBits` should only be active for fix-point version)