### PR TITLE
Optimizations from Hackathon + show Disassembly + Parallel Tests

### DIFF
--- a/dis.sh
+++ b/dis.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+BUILD_DIR="$(dirname $0)/lib"
+if FILE=$(find $BUILD_DIR -type f | grep $1 | egrep "\.o$"); then
+    FOUND_FILES=$(echo $FILE | wc -l)
+    if test $FOUND_FILES -eq "1"; then
+        $(echo $PULP_RISCV_GCC_TOOLCHAIN)/bin/riscv32-unknown-elf-objdump -d $FILE
+    else
+        echo "Multiple matching files found!"
+        exit 1
+    fi
+else
+    echo "No matching file found!"
+    exit 1
+fi

--- a/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_f32s_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_f32s_xpulpv2.c
@@ -61,7 +61,7 @@ void plp_mat_add_stride_f32s_xpulpv2(const float *__restrict__ pSrcA,
                                      uint32_t strideY,
                                      float *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -74,10 +74,34 @@ void plp_mat_add_stride_f32s_xpulpv2(const float *__restrict__ pSrcA,
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    unsigned int step_a = strideA - N;
+    unsigned int step_b = strideB - N;
+    unsigned int step_y = strideY - N;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            float a1 = *pSrcA++;
+            float a2 = *pSrcA++;
+            float b1 = *pSrcB++;
+            float b2 = *pSrcB++;
+            *pDst++ = a1 + b1;
+            *pDst++ = a2 + b2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrcA++ + *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i16p_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i16p_xpulpv2.c
@@ -66,7 +66,7 @@ void plp_mat_add_stride_i16p_xpulpv2(void *args) {
     uint32_t nPE = a->nPE;
     int16_t *__restrict__ pDst = a->pDst;
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -79,10 +79,41 @@ void plp_mat_add_stride_i16p_xpulpv2(void *args) {
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 2;
+    unsigned int n_rem = N & 0x3;
+
+    pSrcA += strideA * core_id;
+    pSrcB += strideB * core_id;
+    pDst += strideY * core_id;
+
+    unsigned int step_a = strideA * nPE - N;
+    unsigned int step_b = strideB * nPE - N;
+    unsigned int step_y = strideY * nPE - N;
+
+    for (m = core_id; m < M; m += nPE) {
+        for (n = 0; n < n_iter; n++) {
+            v2s a1 = *((v2s *)pSrcA);
+            v2s b1 = *((v2s *)pSrcB);
+            v2s a2 = *((v2s *)(pSrcA + 2));
+            v2s b2 = *((v2s *)(pSrcB + 2));
+            *((v2s *)pDst) = __ADD2(a1, b1);
+            *((v2s *)(pDst + 2)) = __ADD2(a2, b2);
+            pSrcA += 4;
+            pSrcB += 4;
+            pDst += 4;
+        }
+        for (n = 0; n < n_rem; n++) {
+            *pDst++ = *pSrcA++ + *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i16s_rv32im.c
+++ b/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i16s_rv32im.c
@@ -91,7 +91,7 @@ void plp_mat_add_stride_i16s_rv32im(const int16_t *__restrict__ pSrcA,
                                     uint32_t strideY,
                                     int16_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don' forget to also use undefine at end of file
+//#define BASIC_VERSION // if used don' forget to also use undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -104,10 +104,34 @@ void plp_mat_add_stride_i16s_rv32im(const int16_t *__restrict__ pSrcA,
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    unsigned int step_a = strideA - N;
+    unsigned int step_b = strideB - N;
+    unsigned int step_y = strideY - N;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            int16_t a1 = *pSrcA++;
+            int16_t a2 = *pSrcA++;
+            int16_t b1 = *pSrcB++;
+            int16_t b2 = *pSrcB++;
+            *pDst++ = a1 + b1;
+            *pDst++ = a2 + b2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrcA++ + *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i16s_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i16s_xpulpv2.c
@@ -61,7 +61,7 @@ void plp_mat_add_stride_i16s_xpulpv2(const int16_t *__restrict__ pSrcA,
                                      uint32_t strideY,
                                      int16_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -74,10 +74,37 @@ void plp_mat_add_stride_i16s_xpulpv2(const int16_t *__restrict__ pSrcA,
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 2;
+    unsigned int n_rem = N & 0x3;
+
+    unsigned int step_a = strideA - N;
+    unsigned int step_b = strideB - N;
+    unsigned int step_y = strideY - N;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            v2s a1 = *((v2s *)pSrcA);
+            v2s b1 = *((v2s *)pSrcB);
+            v2s a2 = *((v2s *)(pSrcA + 2));
+            v2s b2 = *((v2s *)(pSrcB + 2));
+            *((v2s *)pDst) = __ADD2(a1, b1);
+            *((v2s *)(pDst + 2)) = __ADD2(a2, b2);
+            pSrcA += 4;
+            pSrcB += 4;
+            pDst += 4;
+        }
+        for (n = 0; n < n_rem; n++) {
+            *pDst++ = *pSrcA++ + *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 /**
    @} end of MatAddStrideKernels group

--- a/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i32p_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i32p_xpulpv2.c
@@ -62,7 +62,7 @@ void plp_mat_add_stride_i32p_xpulpv2(void *args) {
     uint32_t nPE = a->nPE;
     int32_t *__restrict__ pDst = a->pDst;
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -75,10 +75,38 @@ void plp_mat_add_stride_i32p_xpulpv2(void *args) {
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    pSrcA += strideA * core_id;
+    pSrcB += strideB * core_id;
+    pDst += strideY * core_id;
+
+    unsigned int step_a = strideA * nPE - N;
+    unsigned int step_b = strideB * nPE - N;
+    unsigned int step_y = strideY * nPE - N;
+
+    for (m = core_id; m < M; m += nPE) {
+        for (n = 0; n < n_iter; n++) {
+            int32_t a1 = *pSrcA++;
+            int32_t a2 = *pSrcA++;
+            int32_t b1 = *pSrcB++;
+            int32_t b2 = *pSrcB++;
+            *pDst++ = a1 + b1;
+            *pDst++ = a2 + b2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrcA++ + *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i32s_rv32im.c
+++ b/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i32s_rv32im.c
@@ -61,7 +61,7 @@ void plp_mat_add_stride_i32s_rv32im(const int32_t *__restrict__ pSrcA,
                                     uint32_t strideY,
                                     int32_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don' forget to also use undefine at end of file
+//#define BASIC_VERSION // if used don' forget to also use undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -74,10 +74,34 @@ void plp_mat_add_stride_i32s_rv32im(const int32_t *__restrict__ pSrcA,
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    unsigned int step_a = strideA - N;
+    unsigned int step_b = strideB - N;
+    unsigned int step_y = strideY - N;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            int32_t a1 = *pSrcA++;
+            int32_t a2 = *pSrcA++;
+            int32_t b1 = *pSrcB++;
+            int32_t b2 = *pSrcB++;
+            *pDst++ = a1 + b1;
+            *pDst++ = a2 + b2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrcA++ + *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i32s_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i32s_xpulpv2.c
@@ -61,7 +61,7 @@ void plp_mat_add_stride_i32s_xpulpv2(const int32_t *__restrict__ pSrcA,
                                      uint32_t strideY,
                                      int32_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -74,10 +74,34 @@ void plp_mat_add_stride_i32s_xpulpv2(const int32_t *__restrict__ pSrcA,
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    unsigned int step_a = strideA - N;
+    unsigned int step_b = strideB - N;
+    unsigned int step_y = strideY - N;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            int32_t a1 = *pSrcA++;
+            int32_t a2 = *pSrcA++;
+            int32_t b1 = *pSrcB++;
+            int32_t b2 = *pSrcB++;
+            *pDst++ = a1 + b1;
+            *pDst++ = a2 + b2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrcA++ + *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i8s_rv32im.c
+++ b/src/MatrixFunctionsStride/mat_add_stride/kernels/plp_mat_add_stride_i8s_rv32im.c
@@ -61,7 +61,7 @@ void plp_mat_add_stride_i8s_rv32im(const int8_t *__restrict__ pSrcA,
                                    uint32_t strideY,
                                    int8_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don' forget to also use undefine at end of file
+//#define BASIC_VERSION // if used don' forget to also use undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -74,10 +74,34 @@ void plp_mat_add_stride_i8s_rv32im(const int8_t *__restrict__ pSrcA,
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    unsigned int step_a = strideA - N;
+    unsigned int step_b = strideB - N;
+    unsigned int step_y = strideY - N;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            int8_t a1 = *pSrcA++;
+            int8_t a2 = *pSrcA++;
+            int8_t b1 = *pSrcB++;
+            int8_t b2 = *pSrcB++;
+            *pDst++ = a1 + b1;
+            *pDst++ = a2 + b2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrcA++ + *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_f32s_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_f32s_xpulpv2.c
@@ -57,7 +57,7 @@ void plp_mat_copy_stride_f32s_xpulpv2(const float *__restrict__ pSrc,
                                       uint32_t strideDst,
                                       float *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     for (int m = 0; m < M; m++) {
@@ -68,10 +68,29 @@ void plp_mat_copy_stride_f32s_xpulpv2(const float *__restrict__ pSrc,
 
 #else
 
-    // TODO: Hackathon
+    const int32_t *__restrict__ pSrcI = (int32_t *)pSrc;
+    int32_t *__restrict__ pDstI = (int32_t *)pDst;
+
+    unsigned int m;
+    unsigned int n;
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            *pDstI++ = *pSrcI++;
+            *pDstI++ = *pSrcI++;
+        }
+        if (n_rem) {
+            *pDstI++ = *pSrcI++;
+        }
+        pSrcI += strideSrc - N;
+        pDstI += strideDst - N;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i16p_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i16p_xpulpv2.c
@@ -64,7 +64,7 @@ void plp_mat_copy_stride_i16p_xpulpv2(void *args) {
     uint32_t nPE = a->nPE;
     int16_t *__restrict__ pDst = a->pDst;
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     for (int m = core_id; m < M; m += nPE) {
@@ -75,10 +75,33 @@ void plp_mat_copy_stride_i16p_xpulpv2(void *args) {
 
 #else
 
-    // TODO: Hackathon
+    unsigned int m;
+    unsigned int n;
+
+    pSrc += strideSrc * core_id;
+    pDst += strideDst * core_id;
+
+    unsigned int src_offset = (strideSrc * nPE) - N;
+    unsigned int dst_offset = (strideDst * nPE) - N;
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x00000001;
+
+    for (m = core_id; m < M; m += nPE) {
+        for (n = 0; n < n_iter; n++) {
+            *((int32_t *)pDst) = *((int32_t *)pSrc);
+            pDst += 2;
+            pSrc += 2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrc++;
+        }
+        pSrc += src_offset;
+        pDst += dst_offset;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i16s_rv32im.c
+++ b/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i16s_rv32im.c
@@ -80,7 +80,7 @@ void plp_mat_copy_stride_i16s_rv32im(const int16_t *__restrict__ pSrc,
                                      uint32_t strideDst,
                                      int16_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don' forget to also use undefine at end of file
+//#define BASIC_VERSION // if used don' forget to also use undefine at end of file
 #ifdef BASIC_VERSION
 
     for (int m = 0; m < M; m++) {
@@ -91,10 +91,27 @@ void plp_mat_copy_stride_i16s_rv32im(const int16_t *__restrict__ pSrc,
 
 #else
 
-    // TODO: Hackathon
+    unsigned int m;
+    unsigned int n;
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x00000001;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            *((int32_t *)pDst) = *((int32_t *)pSrc);
+            pDst += 2;
+            pSrc += 2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrc++;
+        }
+        pSrc += strideSrc - N;
+        pDst += strideDst - N;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i16s_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i16s_xpulpv2.c
@@ -57,7 +57,7 @@ void plp_mat_copy_stride_i16s_xpulpv2(const int16_t *__restrict__ pSrc,
                                       uint32_t strideDst,
                                       int16_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     for (int m = 0; m < M; m++) {
@@ -68,10 +68,27 @@ void plp_mat_copy_stride_i16s_xpulpv2(const int16_t *__restrict__ pSrc,
 
 #else
 
-    // TODO: Hackathon
+    unsigned int m;
+    unsigned int n;
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x00000001;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            *((int32_t *)pDst) = *((int32_t *)pSrc);
+            pDst += 2;
+            pSrc += 2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrc++;
+        }
+        pSrc += strideSrc - N;
+        pDst += strideDst - N;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 /**
    @} end of MatCopyStrideKernels group

--- a/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i32p_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i32p_xpulpv2.c
@@ -60,7 +60,7 @@ void plp_mat_copy_stride_i32p_xpulpv2(void *args) {
     uint32_t nPE = a->nPE;
     int32_t *__restrict__ pDst = a->pDst;
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     for (int m = core_id; m < M; m += nPE) {
@@ -71,10 +71,32 @@ void plp_mat_copy_stride_i32p_xpulpv2(void *args) {
 
 #else
 
-    // TODO: Hackathon
+    unsigned int m;
+    unsigned int n;
+
+    pSrc += strideSrc * core_id;
+    pDst += strideDst * core_id;
+
+    unsigned int src_offset = (strideSrc * nPE) - N;
+    unsigned int dst_offset = (strideDst * nPE) - N;
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x00000001;
+
+    for (m = core_id; m < M; m += nPE) {
+        for (n = 0; n < n_iter; n++) {
+            *pDst++ = *pSrc++;
+            *pDst++ = *pSrc++;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrc++;
+        }
+        pSrc += src_offset;
+        pDst += dst_offset;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i32s_rv32im.c
+++ b/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i32s_rv32im.c
@@ -57,7 +57,7 @@ void plp_mat_copy_stride_i32s_rv32im(const int32_t *__restrict__ pSrc,
                                      uint32_t strideDst,
                                      int32_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don' forget to also use undefine at end of file
+//#define BASIC_VERSION // if used don' forget to also use undefine at end of file
 #ifdef BASIC_VERSION
 
     for (int m = 0; m < M; m++) {
@@ -68,10 +68,26 @@ void plp_mat_copy_stride_i32s_rv32im(const int32_t *__restrict__ pSrc,
 
 #else
 
-    // TODO: Hackathon
+    unsigned int m;
+    unsigned int n;
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            *pDst++ = *pSrc++;
+            *pDst++ = *pSrc++;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrc++;
+        }
+        pSrc += strideSrc - N;
+        pDst += strideDst - N;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i32s_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i32s_xpulpv2.c
@@ -57,7 +57,7 @@ void plp_mat_copy_stride_i32s_xpulpv2(const int32_t *__restrict__ pSrc,
                                       uint32_t strideDst,
                                       int32_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     for (int m = 0; m < M; m++) {
@@ -68,10 +68,26 @@ void plp_mat_copy_stride_i32s_xpulpv2(const int32_t *__restrict__ pSrc,
 
 #else
 
-    // TODO: Hackathon
+    unsigned int m;
+    unsigned int n;
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            *pDst++ = *pSrc++;
+            *pDst++ = *pSrc++;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrc++;
+        }
+        pSrc += strideSrc - N;
+        pDst += strideDst - N;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i8s_rv32im.c
+++ b/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i8s_rv32im.c
@@ -57,7 +57,7 @@ void plp_mat_copy_stride_i8s_rv32im(const int8_t *__restrict__ pSrc,
                                     uint32_t strideDst,
                                     int8_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don' forget to also use undefine at end of file
+//#define BASIC_VERSION // if used don' forget to also use undefine at end of file
 #ifdef BASIC_VERSION
 
     for (int m = 0; m < M; m++) {
@@ -68,10 +68,27 @@ void plp_mat_copy_stride_i8s_rv32im(const int8_t *__restrict__ pSrc,
 
 #else
 
-    // TODO: Hackathon
+    unsigned int m;
+    unsigned int n;
+
+    unsigned int n_iter = N >> 2;
+    unsigned int n_rem = N & 0x00000003;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            *((int32_t *)pDst) = *((int32_t *)pSrc);
+            pDst += 4;
+            pSrc += 4;
+        }
+        for (n = 0; n < n_rem; n++) {
+            *pDst++ = *pSrc++;
+        }
+        pSrc += strideSrc - N;
+        pDst += strideDst - N;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i8s_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_copy_stride/kernels/plp_mat_copy_stride_i8s_xpulpv2.c
@@ -57,7 +57,7 @@ void plp_mat_copy_stride_i8s_xpulpv2(const int8_t *__restrict__ pSrc,
                                      uint32_t strideDst,
                                      int8_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     for (int m = 0; m < M; m++) {
@@ -68,10 +68,27 @@ void plp_mat_copy_stride_i8s_xpulpv2(const int8_t *__restrict__ pSrc,
 
 #else
 
-    // TODO: Hackathon
+    unsigned int m;
+    unsigned int n;
+
+    unsigned int n_iter = N >> 2;
+    unsigned int n_rem = N & 0x00000003;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            *((int32_t *)pDst) = *((int32_t *)pSrc);
+            pDst += 4;
+            pSrc += 4;
+        }
+        for (n = 0; n < n_rem; n++) {
+            *pDst++ = *pSrc++;
+        }
+        pSrc += strideSrc - N;
+        pDst += strideDst - N;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 /**
    @} end of MatCopyStrideKernels group

--- a/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_f32p_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_f32p_xpulpv2.c
@@ -63,7 +63,7 @@ void plp_mat_sub_stride_f32p_xpulpv2(void *args) {
     uint32_t nPE = a->nPE;
     float *__restrict__ pDst = a->pDst;
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -76,10 +76,38 @@ void plp_mat_sub_stride_f32p_xpulpv2(void *args) {
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    pSrcA += strideA * core_id;
+    pSrcB += strideB * core_id;
+    pDst += strideY * core_id;
+
+    unsigned int step_a = strideA * nPE - N;
+    unsigned int step_b = strideB * nPE - N;
+    unsigned int step_y = strideY * nPE - N;
+
+    for (m = core_id; m < M; m += nPE) {
+        for (n = 0; n < n_iter; n++) {
+            float a1 = *pSrcA++;
+            float a2 = *pSrcA++;
+            float b1 = *pSrcB++;
+            float b2 = *pSrcB++;
+            *pDst++ = a1 - b1;
+            *pDst++ = a2 - b2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrcA++ - *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_f32s_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_f32s_xpulpv2.c
@@ -61,7 +61,7 @@ void plp_mat_sub_stride_f32s_xpulpv2(const float *__restrict__ pSrcA,
                                      uint32_t strideY,
                                      float *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -74,10 +74,34 @@ void plp_mat_sub_stride_f32s_xpulpv2(const float *__restrict__ pSrcA,
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    unsigned int step_a = strideA - N;
+    unsigned int step_b = strideB - N;
+    unsigned int step_y = strideY - N;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            float a1 = *pSrcA++;
+            float a2 = *pSrcA++;
+            float b1 = *pSrcB++;
+            float b2 = *pSrcB++;
+            *pDst++ = a1 - b1;
+            *pDst++ = a2 - b2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrcA++ - *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i16p_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i16p_xpulpv2.c
@@ -67,7 +67,7 @@ void plp_mat_sub_stride_i16p_xpulpv2(void *args) {
     uint32_t nPE = a->nPE;
     int16_t *__restrict__ pDst = a->pDst;
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -80,10 +80,41 @@ void plp_mat_sub_stride_i16p_xpulpv2(void *args) {
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 2;
+    unsigned int n_rem = N & 0x3;
+
+    pSrcA += strideA * core_id;
+    pSrcB += strideB * core_id;
+    pDst += strideY * core_id;
+
+    unsigned int step_a = strideA * nPE - N;
+    unsigned int step_b = strideB * nPE - N;
+    unsigned int step_y = strideY * nPE - N;
+
+    for (m = core_id; m < M; m += nPE) {
+        for (n = 0; n < n_iter; n++) {
+            v2s a1 = *((v2s *)pSrcA);
+            v2s b1 = *((v2s *)pSrcB);
+            v2s a2 = *((v2s *)(pSrcA + 2));
+            v2s b2 = *((v2s *)(pSrcB + 2));
+            *((v2s *)pDst) = __SUB2(a1, b1);
+            *((v2s *)(pDst + 2)) = __SUB2(a2, b2);
+            pSrcA += 4;
+            pSrcB += 4;
+            pDst += 4;
+        }
+        for (n = 0; n < n_rem; n++) {
+            *pDst++ = *pSrcA++ - *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i16s_rv32im.c
+++ b/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i16s_rv32im.c
@@ -91,7 +91,7 @@ void plp_mat_sub_stride_i16s_rv32im(const int16_t *__restrict__ pSrcA,
                                     uint32_t strideY,
                                     int16_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don' forget to also use undefine at end of file
+//#define BASIC_VERSION // if used don' forget to also use undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -104,10 +104,34 @@ void plp_mat_sub_stride_i16s_rv32im(const int16_t *__restrict__ pSrcA,
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    unsigned int step_a = strideA - N;
+    unsigned int step_b = strideB - N;
+    unsigned int step_y = strideY - N;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            int16_t a1 = *pSrcA++;
+            int16_t a2 = *pSrcA++;
+            int16_t b1 = *pSrcB++;
+            int16_t b2 = *pSrcB++;
+            *pDst++ = a1 - b1;
+            *pDst++ = a2 - b2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrcA++ - *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i16s_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i16s_xpulpv2.c
@@ -61,7 +61,7 @@ void plp_mat_sub_stride_i16s_xpulpv2(const int16_t *__restrict__ pSrcA,
                                      uint32_t strideY,
                                      int16_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -74,10 +74,37 @@ void plp_mat_sub_stride_i16s_xpulpv2(const int16_t *__restrict__ pSrcA,
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 2;
+    unsigned int n_rem = N & 0x3;
+
+    unsigned int step_a = strideA - N;
+    unsigned int step_b = strideB - N;
+    unsigned int step_y = strideY - N;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            v2s a1 = *((v2s *)pSrcA);
+            v2s b1 = *((v2s *)pSrcB);
+            v2s a2 = *((v2s *)(pSrcA + 2));
+            v2s b2 = *((v2s *)(pSrcB + 2));
+            *((v2s *)pDst) = __SUB2(a1, b1);
+            *((v2s *)(pDst + 2)) = __SUB2(a2, b2);
+            pSrcA += 4;
+            pSrcB += 4;
+            pDst += 4;
+        }
+        for (n = 0; n < n_rem; n++) {
+            *pDst++ = *pSrcA++ - *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 /**
    @} end of MatSubStrideKernels group

--- a/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i32p_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i32p_xpulpv2.c
@@ -63,7 +63,7 @@ void plp_mat_sub_stride_i32p_xpulpv2(void *args) {
     uint32_t nPE = a->nPE;
     int32_t *__restrict__ pDst = a->pDst;
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -76,10 +76,38 @@ void plp_mat_sub_stride_i32p_xpulpv2(void *args) {
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    pSrcA += strideA * core_id;
+    pSrcB += strideB * core_id;
+    pDst += strideY * core_id;
+
+    unsigned int step_a = strideA * nPE - N;
+    unsigned int step_b = strideB * nPE - N;
+    unsigned int step_y = strideY * nPE - N;
+
+    for (m = core_id; m < M; m += nPE) {
+        for (n = 0; n < n_iter; n++) {
+            int32_t a1 = *pSrcA++;
+            int32_t a2 = *pSrcA++;
+            int32_t b1 = *pSrcB++;
+            int32_t b2 = *pSrcB++;
+            *pDst++ = a1 - b1;
+            *pDst++ = a2 - b2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrcA++ - *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i32s_rv32im.c
+++ b/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i32s_rv32im.c
@@ -61,7 +61,7 @@ void plp_mat_sub_stride_i32s_rv32im(const int32_t *__restrict__ pSrcA,
                                     uint32_t strideY,
                                     int32_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don' forget to also use undefine at end of file
+//#define BASIC_VERSION // if used don' forget to also use undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -74,10 +74,34 @@ void plp_mat_sub_stride_i32s_rv32im(const int32_t *__restrict__ pSrcA,
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    unsigned int step_a = strideA - N;
+    unsigned int step_b = strideB - N;
+    unsigned int step_y = strideY - N;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            int32_t a1 = *pSrcA++;
+            int32_t a2 = *pSrcA++;
+            int32_t b1 = *pSrcB++;
+            int32_t b2 = *pSrcB++;
+            *pDst++ = a1 - b1;
+            *pDst++ = a2 - b2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrcA++ - *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i32s_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i32s_xpulpv2.c
@@ -61,7 +61,7 @@ void plp_mat_sub_stride_i32s_xpulpv2(const int32_t *__restrict__ pSrcA,
                                      uint32_t strideY,
                                      int32_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -74,10 +74,34 @@ void plp_mat_sub_stride_i32s_xpulpv2(const int32_t *__restrict__ pSrcA,
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    unsigned int step_a = strideA - N;
+    unsigned int step_b = strideB - N;
+    unsigned int step_y = strideY - N;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            int32_t a1 = *pSrcA++;
+            int32_t a2 = *pSrcA++;
+            int32_t b1 = *pSrcB++;
+            int32_t b2 = *pSrcB++;
+            *pDst++ = a1 - b1;
+            *pDst++ = a2 - b2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrcA++ - *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i8s_rv32im.c
+++ b/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i8s_rv32im.c
@@ -61,7 +61,7 @@ void plp_mat_sub_stride_i8s_rv32im(const int8_t *__restrict__ pSrcA,
                                    uint32_t strideY,
                                    int8_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don' forget to also use undefine at end of file
+//#define BASIC_VERSION // if used don' forget to also use undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -74,10 +74,34 @@ void plp_mat_sub_stride_i8s_rv32im(const int8_t *__restrict__ pSrcA,
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    unsigned int n_iter = N >> 1;
+    unsigned int n_rem = N & 0x1;
+
+    unsigned int step_a = strideA - N;
+    unsigned int step_b = strideB - N;
+    unsigned int step_y = strideY - N;
+
+    for (m = 0; m < M; m++) {
+        for (n = 0; n < n_iter; n++) {
+            int8_t a1 = *pSrcA++;
+            int8_t a2 = *pSrcA++;
+            int8_t b1 = *pSrcB++;
+            int8_t b2 = *pSrcB++;
+            *pDst++ = a1 - b1;
+            *pDst++ = a2 - b2;
+        }
+        if (n_rem) {
+            *pDst++ = *pSrcA++ - *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 
 /**

--- a/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i8s_xpulpv2.c
+++ b/src/MatrixFunctionsStride/mat_sub_stride/kernels/plp_mat_sub_stride_i8s_xpulpv2.c
@@ -61,7 +61,7 @@ void plp_mat_sub_stride_i8s_xpulpv2(const int8_t *__restrict__ pSrcA,
                                     uint32_t strideY,
                                     int8_t *__restrict__ pDst) {
 
-#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
+//#define BASIC_VERSION // if used don't forget to also use the undefine at end of file
 #ifdef BASIC_VERSION
 
     uint32_t m, n; // loop counters
@@ -74,10 +74,68 @@ void plp_mat_sub_stride_i8s_xpulpv2(const int8_t *__restrict__ pSrcA,
 
 #else
 
-    // TODO: Hackathon
+    uint32_t m, n; // loop counters
+
+    const int8_t *__restrict__ pSrcA2 = pSrcA + strideA;
+    const int8_t *__restrict__ pSrcB2 = pSrcB + strideB;
+    int8_t *__restrict__ pDst2 = pDst + strideY;
+
+    unsigned int m_iter = M >> 1;
+    unsigned int m_rem = M & 0x1;
+
+    unsigned int n_iter = N >> 2;
+    unsigned int n_rem = N & 0x3;
+
+    unsigned int step_a = strideA * 2 - N;
+    unsigned int step_b = strideB * 2 - N;
+    unsigned int step_y = strideY * 2 - N;
+
+    for (m = 0; m < m_iter; m++) {
+        for (n = 0; n < n_iter; n++) {
+            v4s a1 = *((v4s *)pSrcA);
+            v4s b1 = *((v4s *)pSrcB);
+            v4s a2 = *((v4s *)pSrcA2);
+            v4s b2 = *((v4s *)pSrcB2);
+            *((v4s *)pDst) = __SUB4(a1, b1);
+            *((v4s *)pDst2) = __SUB4(a2, b2);
+            pSrcA += 4;
+            pSrcB += 4;
+            pDst += 4;
+            pSrcA2 += 4;
+            pSrcB2 += 4;
+            pDst2 += 4;
+        }
+        for (n = 0; n < n_rem; n++) {
+            *pDst++ = *pSrcA++ - *pSrcB++;
+            *pDst2++ = *pSrcA2++ - *pSrcB2++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+        pSrcA2 += step_a;
+        pSrcB2 += step_b;
+        pDst2 += step_y;
+    }
+
+    if (m_rem) {
+        for (n = 0; n < n_iter; n++) {
+            v4s a = *((v4s *)pSrcA);
+            v4s b = *((v4s *)pSrcB);
+            *((v4s *)pDst) = __SUB4(a, b);
+            pSrcA += 4;
+            pSrcB += 4;
+            pDst += 4;
+        }
+        for (n = 0; n < n_rem; n++) {
+            *pDst++ = *pSrcA++ - *pSrcB++;
+        }
+        pSrcA += step_a;
+        pSrcB += step_b;
+        pDst += step_y;
+    }
 
 #endif
-#undef BASIC_VERSION
+    //#undef BASIC_VERSION
 }
 /**
    @} end of MatSubStrideKernels group

--- a/test/README.md
+++ b/test/README.md
@@ -392,7 +392,7 @@ This function *must* return the `np.ndarray` with the expected result.
 To execute the tests, you need to change directory into either `test/mrWolf`, or any of it's subdirectories. Then, start plptest with:
 
 ```
-plptest --threads 1
+plptest
 ```
 
 Running all tests will take a while. As soon as all tests are finished, plptest will show you a summary of all executed tests and if they passed or failed.
@@ -401,7 +401,7 @@ Running all tests will take a while. As soon as all tests are finished, plptest 
 
 In recent versions of Pulp-SDK, the platform configuration changed. In earlier versions, the platform could be chosen by sourcing `pulp-sdk/configs/platform-<PLATFORM>.sh`. However, this was removed in recent versions, and replaced by adding the `platform=<PLATFORM>` flag to `make run` (this flag is already available in earlier versions). In order to guarantee compatibility with different Pulp-SDK versions, the test framework chooses the platform in the following way:
 
-- If the environment variable `TEST_PLATFORM` is set, then the tests are run with `make run platform=$TEST_PLATFORM`. Simply run `TEST_PLATFORM=board plptest --threads 1` to execute the tests on an actual board.
+- If the environment variable `TEST_PLATFORM` is set, then the tests are run with `make run platform=$TEST_PLATFORM`. Simply run `TEST_PLATFORM=board plptest` to execute the tests on an actual board.
 - The old platform configuration script `pulp-sdk/configs/platform-<PLATFORM>.sh` sets the environment variable `PULP_CURRENT_CONFIG_ARGS=platform=<PLATFORM>`. If this variable is set (and `TEST_PLATFORM` is not), then the tests are executed with `make run $PULP_CURRENT_CONFIG_ARGS`. This will ensure that the configuration is applied.
 - If neither of the two environment variables `TEST_PLATFORM` or `PULP_CURRENT_CONFIG_ARGS` are set, then the tests are run with `make run platform=gvsoc`.
 
@@ -424,7 +424,7 @@ Every test will measure it's cycles and instructions. After every test is comple
 Sometimes, it is nice to see what went wrong, when writing the tests. When the tests don't compile, the result will also be `KO` (just like if there was a mismatch). However, if there was a mismatch, it will be printed to `stdout` (except the flag `extended_output=False` is overwritten). To see what went wrong, start the tests as follows:
 
 ```
-plptest --threads 1 --stdout
+plptest --stdout
 ```
 
 The test will generate all necessary source files automatically. But, they are removed after the test passed or failed. You can still view the generated files by canceling the test during compilation (by pressing `Ctrl-C`). This should be done about 2 seconds after the test has started (when gcc is executed). Then, you can inspect the files. You can make changes on the fly, and check if it works by manually running `make clean all run`.


### PR DESCRIPTION
# Optimized Functions
- `mat_copy_stride` (all)
- `mat_sub_stride` (all)
- `mat_add_stride` (all)

# Test Framework Changes
- Test can now be executed in parallel (`plptest --threads N`)

# Show the disassembly
Execute `dis.sh` and pass in the function name (like `mat_add_stride_i8p_xpulpv2`) and it shows the disassembly of the requested function using `riscv32-unknown-elf-objdump`, reading the `.o` files of the compiled library.
