### PR TITLE
make plp_dot_prod_f32 overwrite the previous value of variable that holds result

### DIFF
--- a/src/BasicMathFunctions/dot_prod/kernels/plp_dot_prod_f32s_rv32im.c
+++ b/src/BasicMathFunctions/dot_prod/kernels/plp_dot_prod_f32s_rv32im.c
@@ -52,7 +52,7 @@ void plp_dot_prod_f32s_rv32im(const float32_t *__restrict__ pSrcA,
                                const float32_t *__restrict__ pSrcB,
                                uint32_t blockSize,
                                float32_t *__restrict__ pRes) {
-
+  *pRes = 0.0f;
   for (int i = 0; i < blockSize; i++) {
     *pRes += *(pSrcA++) * (*(pSrcB++));
   }

--- a/src/BasicMathFunctions/dot_prod/kernels/plp_dot_prod_f32s_xpulpv2.c
+++ b/src/BasicMathFunctions/dot_prod/kernels/plp_dot_prod_f32s_xpulpv2.c
@@ -52,7 +52,7 @@ void plp_dot_prod_f32s_xpulpv2(const float32_t *__restrict__ pSrcA,
                                const float32_t *__restrict__ pSrcB,
                                uint32_t blockSize,
                                float32_t *__restrict__ pRes) {
-
+    *pRes = 0.0f;
     for (int i = 0; i < blockSize; i++) {
         *pRes += *(pSrcA++) * (*(pSrcB++));
     }


### PR DESCRIPTION
fixed accumulating of result of float32 dot product for single core execution with previous value of the variable that will hold the result of the dot product. for the multi core float32 dot product the result holding variable get's correctly overwritten with the result of the dot product.