### PR TITLE
Distance functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -803,6 +803,7 @@ CL_SRCS = \
 	src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q32p_xpulpv2.c \
 	src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q32s_xpulpv2.c \
 	src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q16s_xpulpv2.c \
+	src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_f32p_xpulpv2.c \
 	src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_f32s_xpulpv2.c \
 	src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q32s_xpulpv2.c \
 	src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q16s_xpulpv2.c \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ FC_SRCS = \
 	src/StatisticsFunctions/plp_min_i32.c src/StatisticsFunctions/kernels/plp_min_i32s_rv32im.c \
 	src/StatisticsFunctions/plp_min_i16.c src/StatisticsFunctions/kernels/plp_min_i16s_rv32im.c \
 	src/StatisticsFunctions/plp_min_i8.c src/StatisticsFunctions/kernels/plp_min_i8s_rv32im.c \
+	src/StatisticsFunctions/plp_power_f32_parallel.c \
+	src/StatisticsFunctions/plp_power_q32_parallel.c \
 	src/StatisticsFunctions/plp_power_f32.c \
+	src/StatisticsFunctions/plp_power_f32.c src/StatisticsFunctions/kernels/plp_power_f32s_rv32im.c \
 	src/StatisticsFunctions/plp_power_i32.c src/StatisticsFunctions/kernels/plp_power_i32s_rv32im.c \
 	src/StatisticsFunctions/plp_power_i16.c src/StatisticsFunctions/kernels/plp_power_i16s_rv32im.c \
 	src/StatisticsFunctions/plp_power_i8.c src/StatisticsFunctions/kernels/plp_power_i8s_rv32im.c \
@@ -19,6 +22,7 @@ FC_SRCS = \
 	src/StatisticsFunctions/plp_power_q16.c src/StatisticsFunctions/kernels/plp_power_q16s_rv32im.c \
 	src/StatisticsFunctions/plp_power_q8.c src/StatisticsFunctions/kernels/plp_power_q8s_rv32im.c \
 	src/FastMathFunctions/plp_sqrt_f32.c \
+	src/FastMathFunctions/plp_sqrt_f32.c src/FastMathFunctions/kernels/plp_sqrt_f32s_rv32im.c \
 	src/FastMathFunctions/plp_sqrt_q32.c src/FastMathFunctions/kernels/plp_sqrt_q32s_rv32im.c \
 	src/FastMathFunctions/plp_sqrt_q16.c src/FastMathFunctions/kernels/plp_sqrt_q16s_rv32im.c \
 	src/FastMathFunctions/plp_sin_f32.c \
@@ -402,7 +406,22 @@ FC_SRCS = \
 	src/ComplexMathFunctions/kernels/plp_cmplx_mag_squared_q16_rv32im.c \
 	src/ComplexMathFunctions/plp_cmplx_mag_squared_q8.c \
 	src/ComplexMathFunctions/kernels/plp_cmplx_mag_squared_q8_rv32im.c \
-
+	src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_f32.c \
+	src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_f32s_rv32im.c \
+	src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_f32_parallel.c \
+	src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_q32.c \
+	src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q32s_rv32im.c \
+	src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_q32_parallel.c \
+	src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_q16.c \
+	src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q16s_rv32im.c \
+	src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_f32.c \
+	src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_f32s_rv32im.c \
+	src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_q32.c \
+	src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q32s_rv32im.c \
+	src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_q16.c \
+	src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q16s_rv32im.c \
+	src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_q32_parallel.c \
+	src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_f32_parallel.c \
 
 CL_SRCS = \
 	src/StatisticsFunctions/kernels/plp_mean_f32s_xpulpv2.c \
@@ -417,10 +436,12 @@ CL_SRCS = \
 	src/StatisticsFunctions/kernels/plp_min_i32s_xpulpv2.c \
 	src/StatisticsFunctions/kernels/plp_min_i16s_xpulpv2.c \
 	src/StatisticsFunctions/kernels/plp_min_i8s_xpulpv2.c \
+	src/StatisticsFunctions/kernels/plp_power_f32p_xpulpv2.c \
 	src/StatisticsFunctions/kernels/plp_power_f32s_xpulpv2.c \
 	src/StatisticsFunctions/kernels/plp_power_i32s_xpulpv2.c \
 	src/StatisticsFunctions/kernels/plp_power_i16s_xpulpv2.c \
 	src/StatisticsFunctions/kernels/plp_power_i8s_xpulpv2.c \
+	src/StatisticsFunctions/kernels/plp_power_q32p_xpulpv2.c \
 	src/StatisticsFunctions/kernels/plp_power_q32s_xpulpv2.c \
 	src/StatisticsFunctions/kernels/plp_power_q16s_xpulpv2.c \
 	src/StatisticsFunctions/kernels/plp_power_q8s_xpulpv2.c \
@@ -777,6 +798,14 @@ CL_SRCS = \
 	src/ComplexMathFunctions/kernels/plp_cmplx_mag_squared_q32_xpulpv2.c \
 	src/ComplexMathFunctions/kernels/plp_cmplx_mag_squared_q16_xpulpv2.c \
 	src/ComplexMathFunctions/kernels/plp_cmplx_mag_squared_q8_xpulpv2.c \
+	src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_f32p_xpulpv2.c \
+	src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_f32s_xpulpv2.c \
+	src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q32p_xpulpv2.c \
+	src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q32s_xpulpv2.c \
+	src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q16s_xpulpv2.c \
+	src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_f32s_xpulpv2.c \
+	src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q32s_xpulpv2.c \
+	src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q16s_xpulpv2.c \
 
 
 IDIR=$(CURDIR)/include

--- a/include/plp_math.h
+++ b/include/plp_math.h
@@ -1442,6 +1442,27 @@ typedef struct {
 } plp_euclidean_distance_instance_q32;
 
 /** -------------------------------------------------------
+    @struct plp_cosine_distance_instance_f32
+    @brief Instance structure for float parallel cosine distance.
+    @param[in]  pSrcA      points to the first input vector
+    @param[in]  pSrcB      points to the second input vector
+    @param[in]  blkSizePE  number of samples in each vector
+    @param[in]  nPE        number of parallel processing units
+    @param[out] resBuffer_A  pointer to the powerA result buffer
+    @param[out] resBuffer_B  pointer to the powerB result buffer
+    @param[out] resBuffer_dot  pointer to the dot_prod result buffer
+*/
+typedef struct {
+    const float32_t *pSrcA; // pointer to the first vector
+    const float32_t *pSrcB; // pointer to the second vector
+    uint32_t blkSizePE;     // number of samples in each vector
+    uint32_t nPE;           // number of processing units
+    float32_t *resBuffer_A;   // pointer to result vector
+    float32_t *resBuffer_B;   // pointer to result vector
+    float32_t *resBuffer_dot;   // pointer to result vector
+} plp_cosine_distance_instance_f32;
+
+/** -------------------------------------------------------
     @struct plp_power_instance_q32
     @brief Instance structure for fixed point parallel power.
     @param[in]  pSrc      points to the first input vector

--- a/include/plp_math.h
+++ b/include/plp_math.h
@@ -18323,6 +18323,15 @@ void plp_cosine_distance_f32_parallel(  const float32_t *__restrict__ pSrcA,
                                         float32_t *__restrict__ pRes);
 
 /**
+  @brief        32-bit floating-point parallel cosine distance between two vectors (computes power in parallel)
+  @param[in]    S points to the instance structure for float cosine distance
+  @return       none
+ */
+
+void plp_cosine_distance_f32p_xpulpv2(void *S);
+
+
+/**
   @brief        Glue code for cosine distance between 32-bit float vectors.
   @param[in]    pSrcA         First vector
   @param[in]    pSrcB         Second vector

--- a/include/plp_math.h
+++ b/include/plp_math.h
@@ -1408,6 +1408,70 @@ typedef struct {
     float *__restrict__ pDst;
 } plp_mat_copy_stride_instance_f32;
 
+/** -------------------------------------------------------
+    @struct plp_euclidean_distance_instance_f32
+    @brief Instance structure for float parallel Euclidean distance.
+    @param[in]  pSrcA      points to the first input vector
+    @param[in]  pSrcB      points to the second input vector
+    @param[in]  blkSizePE  number of samples in each vector
+    @param[in]  nPE        number of parallel processing units
+*/
+typedef struct {
+    const float32_t *pSrcA; // pointer to the first vector
+    const float32_t *pSrcB; // pointer to the second vector
+    uint32_t blkSizePE;     // number of samples in each vector
+    uint32_t nPE;           // number of processing units
+    float32_t *resBuffer;   // pointer to result vector
+} plp_euclidean_distance_instance_f32;
+
+/** -------------------------------------------------------
+    @struct plp_euclidean_distance_instance_q32
+    @brief Instance structure for float parallel Euclidean distance.
+    @param[in]  pSrcA      points to the first input vector
+    @param[in]  pSrcB      points to the second input vector
+    @param[in]  blkSizePE  number of samples in each vector
+    @param[in]  nPE        number of parallel processing units
+*/
+typedef struct {
+    const int32_t *pSrcA;   // pointer to the first vector
+    const int32_t *pSrcB;   // pointer to the second vector
+    uint32_t blkSizePE;     // number of samples in each vector
+    uint32_t nPE;           // number of processing units
+    uint32_t fracBits;      // number of fixed point fractional bits
+    int32_t *resBuffer;     // pointer to result vector
+} plp_euclidean_distance_instance_q32;
+
+/** -------------------------------------------------------
+    @struct plp_power_instance_q32
+    @brief Instance structure for fixed point parallel power.
+    @param[in]  pSrc      points to the first input vector
+    @param[in]  blkSizePE  number of samples in each vector
+    @param[in]  nPE        number of parallel processing units
+    @param[out] resBuffer  pointer to the result buffer
+*/
+typedef struct {
+    int32_t *pSrc;     // pointer to the first vector
+    uint32_t blkSizePE; // number of samples in each vector
+    uint32_t fracBits; // fracBits for right shift
+    uint32_t nPE;       // number of processing units
+    int32_t *resBuffer; // pointer to result vector
+} plp_power_instance_q32;
+
+/** -------------------------------------------------------
+    @struct plp_power_instance_f32
+    @brief Instance structure for float parallel power.
+    @param[in]  pSrc      points to the first input vector
+    @param[in]  blkSizePE  number of samples in each vector
+    @param[in]  nPE        number of parallel processing units
+    @param[out] resBuffer  pointer to the result buffer
+*/
+typedef struct {
+    const float32_t *pSrc; // pointer to the first vector
+    uint32_t blkSizePE;     // number of samples in each vector
+    uint32_t nPE;           // number of processing units
+    float32_t *resBuffer;   // pointer to result vector
+} plp_power_instance_f32;
+
 
 
 typedef enum {
@@ -3484,6 +3548,29 @@ void plp_min_i8s_xpulpv2(const int8_t *__restrict__ pSrc,
                          uint32_t blockSize,
                          int8_t *__restrict__ pRes);
 
+/**
+  @brief Glue code for parallel power of 32-bit floating point vectors.
+  @param[in]  pSrc       points to the input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[in]  nPE        number of parallel processing units
+  @param[out] pRes       output result returned here
+  @return     none
+ */
+
+void plp_power_f32_parallel(const float32_t *__restrict__ pSrc,
+                            uint32_t blockSize,
+                            uint32_t nPE,
+                            float32_t *__restrict__ pRes);
+
+/**
+   @brief          Parallel sum of squares of a 32-bit float vector for XPULPV2 extension.
+   @param[in]  S   points to the instance structure for floating-point parallel power
+   @return         none
+*/
+
+void plp_power_f32p_xpulpv2(void* S);
+
 /** -------------------------------------------------------
     @brief      Glue code for Sum of squares of a 32-bit float vector.
     @param[in]  pSrc       points to the input vector
@@ -3505,6 +3592,18 @@ void plp_power_f32(const float *__restrict__ pSrc, uint32_t blockSize, float *__
 void plp_power_f32s_xpulpv2(const float *__restrict__ pSrc,
                            uint32_t blockSize,
                            float *__restrict__ pRes);
+
+/**
+   @brief         Sum of squares of a 32-bit float vector for RV32IM.
+   @param[in]     pSrc       points to the input vector
+   @param[in]     blockSize  number of samples in input vector
+   @param[out]    pRes    sum of squares returned here
+   @return        none
+*/
+
+void plp_power_f32s_rv32im(const float *__restrict__ pSrc,
+                            uint32_t blockSize,
+                            float *__restrict__ pRes);
 
 /** -------------------------------------------------------
     @brief      Glue code for Sum of squares of a 32-bit integer vector.
@@ -3611,6 +3710,30 @@ void plp_power_i8s_rv32im(const int8_t *__restrict__ pSrc,
 void plp_power_i8s_xpulpv2(const int8_t *__restrict__ pSrc,
                            uint32_t blockSize,
                            int32_t *__restrict__ pRes);
+
+/**
+  @brief Glue code for parallel power of 32-bit fixed point vectors.
+  @param[in]  pSrc       points to the input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[in]  nPE        number of parallel processing units
+  @param[out] pRes       output result returned here
+  @return     none
+ */
+
+void plp_power_q32_parallel(const int32_t *__restrict__ pSrc,
+                            uint32_t blockSize,
+                            uint32_t fracBits,
+                            uint32_t nPE,
+                            int32_t *__restrict__ pRes);
+
+/**
+   @brief          Parallel sum of squares of a 32-bit fixed-point vector for XPULPV2 extension.
+   @param[in]  S   points to the instance structure for fixed-point parallel power
+   @return         none
+*/
+
+void plp_power_q32p_xpulpv2(void *S);
 
 /** -------------------------------------------------------
     @brief      Glue code for Sum of squares of a 32-bit fixed point vector.
@@ -4226,6 +4349,14 @@ void plp_sqrt_q16s_xpulpv2(const int16_t *__restrict__ pSrc,
 void plp_sqrt_f32(const float *__restrict__ pSrc, 
                   float *__restrict__ pRes);
 
+/**
+   @brief         Square root of a 32-bit floating point number for RV32IM.
+   @param[in]     pSrc    points to the input vector
+   @param[out]    pRes    Square root returned here
+   @return        none
+*/
+
+void plp_sqrt_f32s_rv32im(const float *__restrict__ pSrc, float *__restrict__ pRes);
 
 /**
    @brief         Kernel for square root of a 32-bit floating point number.
@@ -17937,5 +18068,386 @@ void plp_cmplx_mult_cmplx_q8_rv32im(const int8_t *__restrict__ pSrcA,
                                     int8_t *__restrict__ pDst,
                                     uint32_t deciPoint,
                                     uint32_t numSamples);
+
+
+/**
+  @brief Glue code for parallel Euclidean distance of 32-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[in]  nPE        number of parallel processing units
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_euclidean_distance_q32_parallel(   const int32_t *__restrict__ pSrcA,
+                                            const int32_t *__restrict__ pSrcB,
+                                            uint32_t blockSize,
+                                            uint32_t fracBits,
+                                            uint32_t nPE,
+                                            uint32_t *__restrict__ pRes);
+
+/**
+  @brief      Glue code for parallel Euclidean distance between 32-bit float vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  nPE        number of parallel processing units
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_euclidean_distance_f32_parallel( const float32_t *__restrict__ pSrcA,
+                                          const float32_t *__restrict__ pSrcB,
+                                          uint32_t blockSize,
+                                          uint32_t nPE,
+                                          float32_t *__restrict__ pRes);
+
+/**
+  @brief          Parallel euclidean distance with interleaved access 32-bit fixed point vectors.
+                  vectors kernel for XPULPV2 extension.
+  @param[in]  S   points to the instance structure for integer parallel dot product
+  @return         none
+ */
+
+void plp_euclidean_distance_q32p_xpulpv2(void *S);
+
+/**
+  @brief        32-bit floating-point parallel Euclidean distance between two vectors
+  @param[in]    S points to the instance structure for float euclidean distance
+  @return       none
+ */
+
+void plp_euclidean_distance_f32p_xpulpv2(void *S);
+
+/**
+  @brief Glue code for euclidean distance of 32-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_euclidean_distance_q32(  const int32_t *__restrict__ pSrcA,
+                                  const int32_t *__restrict__ pSrcB,
+                                  uint32_t blockSize,
+                                  uint32_t fracBits,
+                                  int32_t *__restrict__ pRes);
+
+/**
+  @brief      Euclidean distance of 32-bit fixed point vectors kernel for XPULPV2 extension.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes       output result returned here
+  @return     none
+ */
+
+void plp_euclidean_distance_q32s_xpulpv2(   const int32_t *__restrict__ pSrcA,
+                                            const int32_t *__restrict__ pSrcB,
+                                            uint32_t blockSize,
+                                            uint32_t fracBits,
+                                            int32_t *__restrict__ pRes);
+
+/**
+  @brief      Euclidean distance of 32-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_euclidean_distance_q32s_rv32im(    const int32_t *__restrict__ pSrcA,
+                                            const int32_t *__restrict__ pSrcB,
+                                            uint32_t blockSize,
+                                            uint32_t fracBits,
+                                            int32_t *__restrict__ pRes);
+
+
+/**
+  @brief Glue code for euclidean distance of 16-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_euclidean_distance_q16(  const int16_t *__restrict__ pSrcA,
+                                  const int16_t *__restrict__ pSrcB,
+                                  uint16_t blockSize,
+                                  uint16_t fracBits,
+                                  int32_t *__restrict__ pRes);
+
+/**
+  @brief Euclidean distance of 16-bit fixed point vectors kernel for XPULPV2.
+  @param[in]  pSrcA      points to the first input vector [16 bit]
+  @param[in]  pSrcB      points to the second input vector [16 bit]
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits  decimal point for right shift
+  @param[out] pRes     output result returned here [32 bit]
+  @return     none
+
+  @par Exploiting SIMD instructions
+  The 16 bit values are packed two by two into 32 bit vectors and then the sums and prducts are
+  performed simultaneously on 32 bit vectors, with 32 bit accumulator.
+ */
+
+void plp_euclidean_distance_q16s_xpulpv2(const int16_t *__restrict__ pSrcA,
+                               const int16_t *__restrict__ pSrcB,
+                               uint32_t blockSize,
+                               uint32_t deciPoint,
+                               int32_t *__restrict__ pRes);
+
+/**
+  @brief Euclidean distance of 16-bit fixed point vectors kernel for RV32IM extension.
+  @param[in]  pSrcA      points to the first input vector [16 bit]
+  @param[in]  pSrcB      points to the second input vector [16 bit]
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits  decimal point for right shift
+  @param[out] pRes     output result returned here [32 bit]
+  @return     none
+
+  @par Exploiting SIMD instructions
+  When the ISA supports, the 16 bit values are packed two by two into 32 bit vectors and then the
+  two dot products are performed simultaneously on 32 bit vectors, with 32 bit accumulator. RV32IM
+  doesn't support SIMD. For SIMD, check out other ISA extensions (e.g. XPULPV2).
+ */
+
+void plp_euclidean_distance_q16s_rv32im(const int16_t *__restrict__ pSrcA,
+                              const int16_t *__restrict__ pSrcB,
+                              uint32_t blockSize,
+                              uint32_t fracBits,
+                              int32_t *__restrict__ pRes);
+
+/**
+  @brief        Glue code for Euclidean distance between 32-bit float vectors.
+  @param[in]    pSrcA         First vector
+  @param[in]    pSrcB         Second vector
+  @param[in]    blockSize     vector length
+  @return       none
+ */
+
+void plp_euclidean_distance_f32(  const float32_t *__restrict__ pSrcA,
+                                  const float32_t *__restrict__ pSrcB,
+                                  uint32_t blockSize,
+                                  float32_t *__restrict__ pRes);
+                                    
+/**
+  @brief        32-bit floating point Euclidean distance between two vectors
+  @param[in]    pA         First vector
+  @param[in]    pB         Second vector
+  @param[in]    blockSize  vector length
+  @param[out]   pRes       output result returned here
+  @return       none
+ */
+
+void plp_euclidean_distance_f32s_xpulpv2( const float32_t *__restrict__ pSrcA,
+                                          const float32_t *__restrict__ pSrcB,
+                                          uint32_t blockSize,
+                                          float32_t *__restrict__ pRes);
+                                              
+/**
+  @brief        32-bit floating point Euclidean distance between two vectors
+  @param[in]    pA         First vector
+  @param[in]    pB         Second vector
+  @param[in]    blockSize  vector length
+  @param[out]   pRes       output result returned here
+  @return       none
+ */
+
+void plp_euclidean_distance_f32s_rv32im(  const float32_t *__restrict__ pSrcA,
+                                          const float32_t *__restrict__ pSrcB,
+                                          uint32_t blockSize,
+                                          float32_t *__restrict__ pRes);
+
+/**
+  @brief      Glue code for parallel cosine distance between 32-bit fixed-precision vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  nPE        number of parallel processing units
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_cosine_distance_q32_parallel(   const int32_t *__restrict__ pSrcA,
+                                         const int32_t *__restrict__ pSrcB,
+                                         uint32_t blockSize,
+                                         uint32_t fracBits,
+                                         uint32_t nPE,
+                                         int32_t *__restrict__ pRes);
+
+/**
+  @brief      Glue code for parallel cosine distance between 32-bit float vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  nPE        number of parallel processing units
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_cosine_distance_f32_parallel(  const float32_t *__restrict__ pSrcA,
+                                        const float32_t *__restrict__ pSrcB,
+                                        uint32_t blockSize,
+                                        uint32_t nPE,
+                                        float32_t *__restrict__ pRes);
+
+/**
+  @brief        Glue code for cosine distance between 32-bit float vectors.
+  @param[in]    pSrcA         First vector
+  @param[in]    pSrcB         Second vector
+  @param[in]    blockSize     vector length
+  @return       none
+ */
+
+
+void plp_cosine_distance_f32(  const float32_t *__restrict__ pSrcA,
+                                  const float32_t *__restrict__ pSrcB,
+                                  uint32_t blockSize,
+                                  float32_t *__restrict__ pRes);
+
+/**
+  @brief        32-bit floating point cosine distance between two vectors
+  @param[in]    pA         First vector
+  @param[in]    pB         Second vector
+  @param[in]    blockSize  vector length
+  @param[out]   pRes       output result returned here
+  @return       none
+ */
+
+void plp_cosine_distance_f32s_rv32im(  const float32_t *__restrict__ pSrcA,
+                                          const float32_t *__restrict__ pSrcB,
+                                          uint32_t blockSize,
+                                          float32_t *__restrict__ pRes);
+
+/**
+  @brief        32-bit floating point cosine distance between two vectors
+  @param[in]    pA         First vector
+  @param[in]    pB         Second vector
+  @param[in]    blockSize  vector length
+  @param[out]   pRes       output result returned here
+  @return       none
+ */
+
+void plp_cosine_distance_f32s_xpulpv2(  const float32_t *__restrict__ pSrcA,
+                                        const float32_t *__restrict__ pSrcB,
+                                        uint32_t blockSize,
+                                        float32_t *__restrict__ pRes);
+
+/**
+  @brief Glue code for cosine distance of 32-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_cosine_distance_q32(   const int32_t *__restrict__ pSrcA,
+                                const int32_t *__restrict__ pSrcB,
+                                uint32_t blockSize,
+                                uint32_t fracBits,
+                                int32_t *__restrict__ pRes);
+
+/**
+  @brief      cosine distance of 32-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_cosine_distance_q32s_rv32im(   const int32_t *__restrict__ pSrcA,
+                                        const int32_t *__restrict__ pSrcB,
+                                        uint32_t blockSize,
+                                        uint32_t fracBits,
+                                        int32_t *__restrict__ pRes);
+
+/**
+  @brief      cosine distance of 32-bit fixed point vectors kernel for XPULPV2 extension.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes       output result returned here
+  @return     none
+ */
+
+void plp_cosine_distance_q32s_xpulpv2(   const int32_t *__restrict__ pSrcA,
+                                            const int32_t *__restrict__ pSrcB,
+                                            uint32_t blockSize,
+                                            uint32_t fracBits,
+                                            int32_t *__restrict__ pRes);
+
+/**
+  @brief Glue code for cosine distance of 16-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_cosine_distance_q16(   const int16_t *__restrict__ pSrcA,
+                                const int16_t *__restrict__ pSrcB,
+                                uint16_t blockSize,
+                                uint16_t fracBits,
+                                int32_t *__restrict__ pRes);
+
+/**
+  @brief cosine distance of 16-bit fixed point vectors kernel for RV32IM extension.
+  @param[in]  pSrcA      points to the first input vector [16 bit]
+  @param[in]  pSrcB      points to the second input vector [16 bit]
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits  decimal point for right shift
+  @param[out] pRes     output result returned here [32 bit]
+  @return     none
+
+  @par Exploiting SIMD instructions
+  When the ISA supports, the 16 bit values are packed two by two into 32 bit vectors and then the
+  two dot products are performed simultaneously on 32 bit vectors, with 32 bit accumulator. RV32IM
+  doesn't support SIMD. For SIMD, check out other ISA extensions (e.g. XPULPV2).
+ */
+
+void plp_cosine_distance_q16s_rv32im(const int16_t *__restrict__ pSrcA,
+                              const int16_t *__restrict__ pSrcB,
+                              uint32_t blockSize,
+                              uint32_t fracBits,
+                              int32_t *__restrict__ pRes);
+
+/**
+  @brief cosine distance of 16-bit fixed point vectors kernel for XPULPV2.
+  @param[in]  pSrcA      points to the first input vector [16 bit]
+  @param[in]  pSrcB      points to the second input vector [16 bit]
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits  decimal point for right shift
+  @param[out] pRes     output result returned here [32 bit]
+  @return     none
+
+  @par Exploiting SIMD instructions
+  The 16 bit values are packed two by two into 32 bit vectors and then the sums and prducts are
+  performed simultaneously on 32 bit vectors, with 32 bit accumulator.
+ */
+
+void plp_cosine_distance_q16s_xpulpv2(const int16_t *__restrict__ pSrcA,
+                               const int16_t *__restrict__ pSrcB,
+                               uint32_t blockSize,
+                               uint32_t fracBits,
+                               int32_t *__restrict__ pRes);
+
+
 
 #endif // __PLP_MATH_H__

--- a/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_f32p_xpulpv2.c
+++ b/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_f32p_xpulpv2.c
@@ -1,0 +1,85 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_cosine_distance_f32p_xpulpv2.c
+ * Description:  32-bit floating-point cosine distance for XPULPV2
+ *
+ * $Date:        28 Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup cosine distance
+  cosine distance
+ */
+
+/**
+  @addtogroup cosine
+  @{
+ */
+
+/**
+  @brief        32-bit floating-point parallel cosine distance between two vectors (computes power in parallel)
+  @param[in]    S points to the instance structure for float cosine distance
+  @return       none
+ */
+
+void plp_cosine_distance_f32p_xpulpv2(void *S) {
+
+    float32_t *pSrcA = (float32_t *)(((plp_euclidean_distance_instance_f32 *)S)->pSrcA) + hal_core_id();
+    float32_t *pSrcB = (float32_t *)(((plp_euclidean_distance_instance_f32 *)S)->pSrcB) + hal_core_id();
+    uint32_t blkSizePE = ((plp_euclidean_distance_instance_f32 *)S)->blkSizePE;
+    uint32_t nPE = ((plp_euclidean_distance_instance_f32 *)S)->nPE;
+    float32_t *resBufferPE_A = &(((plp_cosine_distance_instance_f32 *)S)->resBuffer_A[hal_core_id()]);
+    float32_t *resBufferPE_B = &(((plp_cosine_distance_instance_f32 *)S)->resBuffer_B[hal_core_id()]);
+    float32_t *resBufferPE_dot = &(((plp_cosine_distance_instance_f32 *)S)->resBuffer_dot[hal_core_id()]);
+
+    uint32_t blkCnt = 0;
+    float32_t accum_A = 0.0f, accum_B = 0.0f, accum_dot = 0.0f, tmp_A, tmp_B;
+    for (blkCnt = 0; blkCnt < blkSizePE; blkCnt++) {
+        tmp_A = pSrcA[nPE * blkCnt];
+        tmp_B = pSrcB[nPE * blkCnt];
+        accum_A += tmp_A*tmp_A;
+        accum_B += tmp_B*tmp_B;
+        accum_dot += tmp_A*tmp_B;
+    }
+    *resBufferPE_A = accum_A;
+    *resBufferPE_B = accum_B;
+    *resBufferPE_dot = accum_dot;
+}
+
+
+/**
+   @} end of cosine group
+*/

--- a/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_f32s_rv32im.c
+++ b/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_f32s_rv32im.c
@@ -1,0 +1,74 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_cosine_distance_f32s_rv32im.c
+ * Description:  32-bit floating point cosine_distance kernel for RV32IM
+ *
+ * $Date:        21 Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup  DistanceFunctions
+ */
+
+/**
+  @defgroup cosine distance
+  cosine distance
+ */
+
+/**
+  @addtogroup cosine
+  @{
+ */
+
+/**
+  @brief        32-bit floating point cosine distance between two vectors
+  @param[in]    pA         First vector
+  @param[in]    pB         Second vector
+  @param[in]    blockSize  vector length
+  @param[out]   pRes       output result returned here
+  @return       none
+ */
+
+void plp_cosine_distance_f32s_rv32im(   const float32_t *__restrict__ pSrcA,
+                                        const float32_t *__restrict__ pSrcB,
+                                        uint32_t blockSize,
+                                        float32_t *__restrict__ pRes) {
+  float32_t pwrA, pwrB;
+  float32_t dot, tmp;
+  plp_power_f32s_rv32im(pSrcA, blockSize, &pwrA);
+  plp_power_f32s_rv32im(pSrcB, blockSize, &pwrB);
+  tmp = pwrA*pwrB;
+
+  plp_dot_prod_f32s_rv32im(pSrcA, pSrcB, blockSize, &dot);
+  plp_sqrt_f32s_rv32im(&tmp, &tmp);
+  *pRes = 1.0f - dot/tmp;
+
+}
+
+/**
+   @} end of  cosine group
+*/

--- a/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_f32s_xpulpv2.c
+++ b/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_f32s_xpulpv2.c
@@ -1,0 +1,75 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_cosine_distance_f32s_xpulpv2.c
+ * Description:  32-bit floating-point cosine distance kernel for RV32IM
+ *
+ * $Date:        21. March 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup cosine distance
+  cosine distance
+ */
+
+/**
+  @addtogroup cosine
+  @{
+ */
+
+/**
+  @brief        32-bit floating point cosine distance between two vectors
+  @param[in]    pA         First vector
+  @param[in]    pB         Second vector
+  @param[in]    blockSize  vector length
+  @param[out]   pRes       output result returned here
+  @return       none
+ */
+
+void plp_cosine_distance_f32s_xpulpv2(  const float32_t *__restrict__ pSrcA,
+                                        const float32_t *__restrict__ pSrcB,
+                                        uint32_t blockSize,
+                                        float32_t *__restrict__ pRes) {
+
+  float32_t pwrA, pwrB;
+  float32_t dot, tmp;
+  plp_power_f32s_xpulpv2(pSrcA, blockSize, &pwrA);
+  plp_power_f32s_xpulpv2(pSrcB, blockSize, &pwrB);
+  tmp = pwrA*pwrB;
+
+  plp_dot_prod_f32s_xpulpv2(pSrcA, pSrcB, blockSize, &dot);
+  plp_sqrt_f32s_xpulpv2(&tmp, &tmp);
+  *pRes = 1.0f - dot/tmp;
+
+}
+
+/**
+   @} end of cosine group
+*/

--- a/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q16s_rv32im.c
+++ b/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q16s_rv32im.c
@@ -1,0 +1,87 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_cosine_distance_q16s_rv32im.c
+ * Description:  16-bit fixed-point cosine_distance kernel for RV32IM
+ *
+ * $Date:        21 mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2019 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup  DistanceFunctions
+ */
+
+/**
+  @defgroup cosine distance
+  cosine distance
+ */
+
+/**
+  @addtogroup cosine
+  @{
+ */
+
+/**
+  @brief cosine distance of 16-bit fixed point vectors kernel for RV32IM extension.
+  @param[in]  pSrcA      points to the first input vector [16 bit]
+  @param[in]  pSrcB      points to the second input vector [16 bit]
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits  decimal point for right shift
+  @param[out] pRes     output result returned here [32 bit]
+  @return     none
+
+  @par Exploiting SIMD instructions
+  When the ISA supports, the 16 bit values are packed two by two into 32 bit vectors and then the
+  two dot products are performed simultaneously on 32 bit vectors, with 32 bit accumulator. RV32IM
+  doesn't support SIMD. For SIMD, check out other ISA extensions (e.g. XPULPV2).
+ */
+
+void plp_cosine_distance_q16s_rv32im(const int16_t *__restrict__ pSrcA,
+                              const int16_t *__restrict__ pSrcB,
+                              uint32_t blockSize,
+                              uint32_t fracBits,
+                              int32_t *__restrict__ pRes) {
+
+    int32_t pwrA, pwrB;
+    int32_t dot, tmp;
+    plp_power_q16s_rv32im(pSrcA, blockSize, fracBits, &pwrA);
+    plp_power_q16s_rv32im(pSrcB, blockSize, fracBits, &pwrB);
+    tmp = pwrA*pwrB >> fracBits;
+
+    plp_dot_prod_q16s_rv32im(pSrcA, pSrcB, blockSize, fracBits, &dot);
+    plp_sqrt_q32s_rv32im(&tmp, fracBits, &tmp);
+    *pRes = 1 - dot/tmp;
+
+}
+
+/**
+   @} end of cosine group
+*/

--- a/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q16s_xpulpv2.c
+++ b/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q16s_xpulpv2.c
@@ -1,0 +1,86 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_cosine_distance_q16s_xpulpv2.c
+ * Description:  16-bit fixed-point vectorized cosine distance for XPULPV2
+ *
+ * $Date:        21. Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2019 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup  DistanceFunctions
+ */
+
+/**
+  @defgroup cosine distance
+  cosine distance
+ */
+
+/**
+  @addtogroup cosine
+  @{
+ */
+
+/**
+  @brief cosine distance of 16-bit fixed-point vectors kernel for XPULPV2.
+  @param[in]  pSrcA      points to the first input vector [16 bit]
+  @param[in]  pSrcB      points to the second input vector [16 bit]
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits  decimal point for right shift
+  @param[out] pRes      output result returned here [32 bit]
+  @return     none
+
+  @par Exploiting SIMD instructions
+  The 16 bit values are packed two by two into 32 bit vectors and then the sums and prducts are
+  performed simultaneously on 32 bit vectors, with 32 bit accumulator.
+ */
+
+void plp_cosine_distance_q16s_xpulpv2(const int16_t *__restrict__ pSrcA,
+                               const int16_t *__restrict__ pSrcB,
+                               uint32_t blockSize,
+                               uint32_t fracBits,
+                               int32_t *__restrict__ pRes) {
+    
+    int32_t pwrA, pwrB;
+    int32_t dot, tmp;
+    plp_power_q16s_xpulpv2(pSrcA, blockSize, fracBits, &pwrA);
+    plp_power_q16s_xpulpv2(pSrcB, blockSize, fracBits, &pwrB);
+    tmp = pwrA*pwrB >> fracBits;
+
+    plp_dot_prod_q16s_xpulpv2(pSrcA, pSrcB, blockSize, fracBits, &dot);
+    plp_sqrt_q32s_xpulpv2(&tmp, fracBits, &tmp);
+    *pRes = 1 - dot/tmp;
+ 
+}
+
+/**
+   @} end of cosine group
+*/

--- a/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q32s_rv32im.c
+++ b/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q32s_rv32im.c
@@ -1,0 +1,82 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_cosine_distance_q32s_rv32im.c
+ * Description:  32-bit fixed-point cosine distance kernel for RV32IM
+ *
+ * $Date:        21. Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup cosine distance
+  cosine distance
+ */
+
+/**
+  @addtogroup cosine
+  @{
+ */
+
+/**
+  @brief      cosine distance of 32-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed-point fractional bits
+  @param[out] pRes       output result returned here
+  @return     none
+ */
+
+void plp_cosine_distance_q32s_rv32im(   const int32_t *__restrict__ pSrcA,
+                                        const int32_t *__restrict__ pSrcB,
+                                        uint32_t blockSize,
+                                        uint32_t fracBits,
+                                        int32_t *__restrict__ pRes) {
+
+  int32_t pwrA, pwrB;
+  int32_t dot, tmp;
+  plp_power_q32s_rv32im(pSrcA, blockSize, fracBits, &pwrA);
+  plp_power_q32s_rv32im(pSrcB, blockSize, fracBits, &pwrB);
+  tmp = pwrA*pwrB >> fracBits;
+
+  plp_dot_prod_q32s_rv32im(pSrcA, pSrcB, blockSize, fracBits, &dot);
+  plp_sqrt_q32s_rv32im(&tmp, fracBits, &tmp);
+  *pRes = 1 - dot/tmp;
+
+}
+
+/**
+   @} end of cosine group
+*/

--- a/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q32s_xpulpv2.c
+++ b/src/DistanceFunctions/plp_cosine_distance/kernels/plp_cosine_distance_q32s_xpulpv2.c
@@ -1,0 +1,83 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_cosine_distance_q32s_xpulpv2.c
+ * Description:  32-bit fixed-point cosine distance for XPULPV2
+ *
+ * $Date:        21. Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup cosine distance
+  cosine distance
+ */
+
+/**
+  @addtogroup cosine
+  @{
+ */
+
+/**
+  @brief      cosine distance of 32-bit fixed-point vectors kernel for XPULPV2 extension.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes       output result returned here
+  @return     none
+ */
+
+void plp_cosine_distance_q32s_xpulpv2(   const int32_t *__restrict__ pSrcA,
+                                            const int32_t *__restrict__ pSrcB,
+                                            uint32_t blockSize,
+                                            uint32_t fracBits,
+                                            int32_t *__restrict__ pRes) {
+    
+  int32_t pwrA, pwrB;
+  int32_t dot, tmp;
+  plp_power_q32s_xpulpv2(pSrcA, blockSize, fracBits, &pwrA);
+  plp_power_q32s_xpulpv2(pSrcB, blockSize, fracBits, &pwrB);
+  tmp = pwrA*pwrB >> fracBits;
+
+  plp_dot_prod_q32s_xpulpv2(pSrcA, pSrcB, blockSize, fracBits, &dot);
+  plp_sqrt_q32s_xpulpv2(&tmp, fracBits, &tmp);
+  *pRes = 1 - dot/tmp;
+
+}
+
+
+/**
+   @} end of cosine group
+*/

--- a/src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_f32.c
+++ b/src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_f32.c
@@ -1,0 +1,76 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_dot_prod_f32.c
+ * Description:  32-bit floating-point cosine-distance glue code
+ *
+ * $Date:        8. March 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup  DistanceFunctions
+ */
+
+/**
+  @defgroup cosine distance
+  cosine distance
+ */
+
+/**
+  @addtogroup cosine
+  @{
+ */
+
+/**
+  @brief        Glue code for cosine distance between 32-bit floating-point vectors.
+  @param[in]    pSrcA         First vector
+  @param[in]    pSrcB         Second vector
+  @param[in]    blockSize     vector length
+  @return       none
+ */
+
+
+void plp_cosine_distance_f32(  const float32_t *__restrict__ pSrcA,
+                                  const float32_t *__restrict__ pSrcB,
+                                  uint32_t blockSize,
+                                  float32_t *__restrict__ pRes) {
+
+    if (hal_cluster_id() == ARCHI_FC_CID) {
+        //printf("Note: FC doesn't have FPU\n");
+        plp_cosine_distance_f32s_rv32im(pSrcA, pSrcB, blockSize, pRes);
+    } else {
+        plp_cosine_distance_f32s_xpulpv2(pSrcA, pSrcB, blockSize, pRes);
+    }
+}
+
+/**
+  @} end of cosine group
+ */

--- a/src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_f32_parallel.c
+++ b/src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_f32_parallel.c
@@ -1,0 +1,76 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_cosine_distance_f32_parallel.c
+ * Description:  32-bit floating point cosine distance kernel for RV32IM
+ *
+ * $Date:        21. March 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup cosine distance
+  cosine distance
+ */
+
+/**
+  @addtogroup cosine
+  @{
+ */
+
+/**
+  @brief      Glue code for parallel cosine distance between 32-bit float vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  nPE        number of parallel processing units
+  @param[out] pRes       output result returned here
+  @return     none
+ */
+
+void plp_cosine_distance_f32_parallel(  const float32_t *__restrict__ pSrcA,
+                                        const float32_t *__restrict__ pSrcB,
+                                        uint32_t blockSize,
+                                        uint32_t nPE,
+                                        float32_t *__restrict__ pRes) {
+  float32_t pwrA, pwrB;
+  float32_t dot, tmp;
+  plp_power_f32_parallel(pSrcA, blockSize, nPE, &pwrA);
+  plp_power_f32_parallel(pSrcB, blockSize, nPE, &pwrB);
+  tmp = pwrA*pwrB;
+
+  plp_dot_prod_f32_parallel(pSrcA, pSrcB, blockSize, nPE, &dot);
+  plp_sqrt_f32(&tmp, &tmp);
+  *pRes = 1.0f - dot/tmp;
+
+}
+
+/**
+   @} end of cosine group
+*/

--- a/src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_f32_parallel.c
+++ b/src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_f32_parallel.c
@@ -59,7 +59,7 @@ void plp_cosine_distance_f32_parallel(  const float32_t *__restrict__ pSrcA,
                                         uint32_t blockSize,
                                         uint32_t nPE,
                                         float32_t *__restrict__ pRes) {
-  float32_t pwrA, pwrB;
+  /*float32_t pwrA, pwrB;
   float32_t dot, tmp;
   plp_power_f32_parallel(pSrcA, blockSize, nPE, &pwrA);
   plp_power_f32_parallel(pSrcB, blockSize, nPE, &pwrB);
@@ -67,7 +67,108 @@ void plp_cosine_distance_f32_parallel(  const float32_t *__restrict__ pSrcA,
 
   plp_dot_prod_f32_parallel(pSrcA, pSrcB, blockSize, nPE, &dot);
   plp_sqrt_f32(&tmp, &tmp);
-  *pRes = 1.0f - dot/tmp;
+  *pRes = 1.0f - dot/tmp;*/
+
+  if (hal_cluster_id() == ARCHI_FC_CID) {
+        printf("parallel processing supported only for cluster side\n");
+        return;
+    } else {
+
+
+        uint32_t i;
+        uint32_t tmpblkSizePE = blockSize / 2;
+        float32_t resBuffer_A[2];
+        float32_t resBuffer_B[2];
+        float32_t resBuffer_dot[2];
+        plp_cosine_distance_instance_f32 S;
+
+        // Initialize the plp_cosine_distance_instance
+        S.pSrcA = pSrcA;
+        S.pSrcB = pSrcB;
+        S.blkSizePE = tmpblkSizePE;
+        S.nPE = 2;
+        S.resBuffer_A = resBuffer_A;
+        S.resBuffer_B = resBuffer_B;
+        S.resBuffer_dot = resBuffer_dot;
+
+        hal_cl_team_fork(2, plp_cosine_distance_f32p_xpulpv2, (void *)&S);
+
+        float32_t pwrA = 0, pwrB=0;
+        float32_t dot = 0;
+        for (i = 0; i < 2; i++) { // not necessary hal_cl_nb_pe_cores()
+            pwrA += resBuffer_A[i];
+            pwrB += resBuffer_B[i];
+            dot += resBuffer_dot[i];
+        }
+
+
+        /*uint32_t nPEdot = nPE;
+        uint32_t nPEpwr = nPE;
+
+        uint32_t i;
+        uint32_t tmpblkSizePE_pwr = blockSize / nPEpwr;
+        float32_t resBuffer_pwr[nPEpwr];
+        plp_power_instance_f32 S_pwr;
+        // Initialize the plp_power_instance
+        S_pwr.blkSizePE = tmpblkSizePE_pwr;
+        S_pwr.nPE = nPE;
+        S_pwr.resBuffer = resBuffer_pwr;
+
+        // POWER OF THE FIRST VECTOR
+        S_pwr.pSrc = pSrcA;
+        // Fork the dot product to nPE cores (i.e. processing units)
+        hal_cl_team_fork(nPEpwr, plp_power_f32p_xpulpv2, (void *)&S_pwr);
+        float32_t pwrA = 0, tmpA;
+        for (i = 0; i < nPE; i++) { // not necessary hal_cl_nb_pe_cores()
+            pwrA += resBuffer_pwr[i];
+        }
+        for (i = (tmpblkSizePE_pwr)*nPEpwr; i < blockSize; i++) {
+            tmpA = pSrcA[i];
+            pwrA += tmpA*tmpA;
+        }
+
+        // POWER OF THE SECOND VECTOR
+        S_pwr.pSrc = pSrcB;
+        // Fork the dot product to nPE cores (i.e. processing units)
+        hal_cl_team_fork(nPE, plp_power_f32p_xpulpv2, (void *)&S_pwr);
+        float32_t pwrB = 0, tmpB;
+        for (i = 0; i < nPE; i++) { // not necessary hal_cl_nb_pe_cores()
+            pwrB += resBuffer_pwr[i];
+        }
+        for (i = (tmpblkSizePE_pwr)*nPEpwr; i < blockSize; i++) {
+            tmpB = pSrcB[i];
+            pwrB += tmpB*tmpB;
+        }
+
+        // DOT PRODUCT
+        float32_t dot = 0;
+        plp_dot_prod_f32s_xpulpv2(pSrcA, pSrcB, blockSize, &dot);
+
+        // DOT PRODUCT
+        uint32_t tmpblkSizePE_dot = blockSize / nPEdot;
+        float32_t resBuffer_dot[nPEdot];
+        plp_dot_prod_instance_f32 S_dot;
+        // Initialize the plp_dot_prod_instance
+        S_dot.pSrcA = pSrcA;
+        S_dot.pSrcB = pSrcB;
+        S_dot.blkSizePE = tmpblkSizePE_dot;
+        S_dot.nPE = nPEdot;
+        S_dot.resBuffer = resBuffer_dot;
+
+        // Fork the dot product to nPE cores (i.e. processing units)
+        hal_cl_team_fork(nPEdot, plp_dot_prod_f32p_xpulpv2, (void *)&S_dot);
+        float32_t dot = 0;
+        for (i = 0; i < nPEdot; i++) { // not necessary hal_cl_nb_pe_cores()
+            dot += resBuffer_dot[i];
+        }
+        for (i = (tmpblkSizePE_dot)*nPEdot; i < blockSize; i++) {
+            dot += pSrcA[i] * pSrcB[i];
+        }*/
+
+        float32_t tmp = pwrA*pwrB;
+        plp_sqrt_f32(&tmp, &tmp);
+        *pRes = 1.0f - dot/tmp;
+    }
 
 }
 

--- a/src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_q16.c
+++ b/src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_q16.c
@@ -1,0 +1,77 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_cosine_distance_q32.c
+ * Description:  32-bit fixed-point cosine distance glue code
+ *
+ * $Date:        21. Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup  DistanceFunctions
+ */
+
+/**
+  @defgroup cosine distance
+  cosine distance
+ */
+
+/**
+  @addtogroup cosine
+  @{
+ */
+
+/**
+  @brief Glue code for cosine distance of 16-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes       output result returned here
+  @return     none
+ */
+
+void plp_cosine_distance_q16(   const int16_t *__restrict__ pSrcA,
+                                const int16_t *__restrict__ pSrcB,
+                                uint16_t blockSize,
+                                uint16_t fracBits,
+                                int32_t *__restrict__ pRes) {
+
+    if (hal_cluster_id() == ARCHI_FC_CID) {
+        plp_cosine_distance_q16s_rv32im(pSrcA, pSrcB, blockSize, fracBits, pRes);
+    } else {
+        plp_cosine_distance_q16s_xpulpv2(pSrcA, pSrcB, blockSize, fracBits, pRes);
+    }
+}
+
+/**
+  @} end of cosine group
+ */

--- a/src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_q32.c
+++ b/src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_q32.c
@@ -1,0 +1,77 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_cosine_distance_q32.c
+ * Description:  32-bit floating-point cosine distance glue code
+ *
+ * $Date:        17. Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup  DistanceFunctions
+ */
+
+/**
+  @defgroup cosine distance
+  cosine distance
+ */
+
+/**
+  @addtogroup cosine
+  @{
+ */
+
+/**
+  @brief Glue code for cosine distance of 32-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes       output result returned here
+  @return     none
+ */
+
+void plp_cosine_distance_q32(  const int32_t *__restrict__ pSrcA,
+                                  const int32_t *__restrict__ pSrcB,
+                                  uint32_t blockSize,
+                                  uint32_t fracBits,
+                                  int32_t *__restrict__ pRes) {
+
+    if (hal_cluster_id() == ARCHI_FC_CID) {
+        plp_cosine_distance_q32s_rv32im(pSrcA, pSrcB, blockSize, fracBits, pRes);
+    } else {
+        plp_cosine_distance_q32s_xpulpv2(pSrcA, pSrcB, blockSize, fracBits, pRes);
+    }
+}
+
+/**
+  @} end of cosine group
+ */

--- a/src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_q32_parallel.c
+++ b/src/DistanceFunctions/plp_cosine_distance/plp_cosine_distance_q32_parallel.c
@@ -1,0 +1,82 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_cosine_distance_q32_parallel.c
+ * Description:  32-bit fixed-point parallel cosine distance
+ *
+ * $Date:        15 Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup cosine distance
+  cosine distance
+ */
+
+/**
+  @addtogroup cosine
+  @{
+ */
+
+/**
+  @brief      Glue code for parallel cosine distance between 32-bit fixed-point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  nPE        number of parallel processing units
+  @param[out] pRes       output result returned here
+  @return     none
+ */
+
+void plp_cosine_distance_q32_parallel(  const int32_t *__restrict__ pSrcA,
+                                        const int32_t *__restrict__ pSrcB,
+                                        uint32_t blockSize,
+                                        uint32_t fracBits,
+                                        uint32_t nPE,
+                                        int32_t *__restrict__ pRes) {
+  int32_t pwrA, pwrB;
+  int32_t dot, tmp;
+  plp_power_q32_parallel(pSrcA, blockSize, fracBits, nPE, &pwrA);
+  plp_power_q32_parallel(pSrcB, blockSize, fracBits, nPE, &pwrB);
+  tmp = pwrA*pwrB;
+
+  plp_dot_prod_q32_parallel(pSrcA, pSrcB, blockSize, fracBits, nPE, &dot);
+  plp_sqrt_q32s_xpulpv2(&tmp, fracBits, &tmp);
+  *pRes = 1 - dot/tmp;
+}
+
+
+/**
+   @} end of cosine group
+*/

--- a/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_f32p_xpulpv2.c
+++ b/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_f32p_xpulpv2.c
@@ -1,0 +1,79 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_euclidean_distance_f32p_xpulpv2.c
+ * Description:  32-bit floating-point Euclidean distance for XPULPV2 with interleaved access
+ *
+ * $Date:        15 Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup Euclidean distance
+  Euclidean distance
+ */
+
+/**
+  @addtogroup Euclidean
+  @{
+ */
+
+/**
+  @brief        32-bit floating-point parallel Euclidean distance between two vectors
+  @param[in]    S points to the instance structure for float euclidean distance
+  @return       none
+ */
+
+void plp_euclidean_distance_f32p_xpulpv2(void *S) {
+
+    float32_t *pSrcA = (float32_t *)(((plp_euclidean_distance_instance_f32 *)S)->pSrcA) + hal_core_id();
+    float32_t *pSrcB = (float32_t *)(((plp_euclidean_distance_instance_f32 *)S)->pSrcB) + hal_core_id();
+    uint32_t blkSizePE = ((plp_euclidean_distance_instance_f32 *)S)->blkSizePE;
+    uint32_t nPE = ((plp_euclidean_distance_instance_f32 *)S)->nPE;
+    float32_t *resBufferPE = &(((plp_euclidean_distance_instance_f32 *)S)->resBuffer[hal_core_id()]);
+
+    uint32_t blkCnt, tmpBS; /* Loop counter, temporal BlockSize */
+
+    float32_t accum = 0.0f, tmp;
+    for (blkCnt = 0; blkCnt < blkSizePE; blkCnt++) {
+        tmp = pSrcA[nPE * blkCnt] - pSrcB[nPE * blkCnt];
+        accum += tmp*tmp;
+    }
+    *resBufferPE = accum;
+}
+
+
+/**
+   @} end of Euclidean group
+*/

--- a/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_f32s_rv32im.c
+++ b/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_f32s_rv32im.c
@@ -1,0 +1,73 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_euclidean_distance_f32p_rv32im.c
+ * Description:  32-bit floating point Euclidean distance for RV32IM
+ *
+ * $Date:        15 Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup Euclidean distance
+  Euclidean distance
+ */
+
+/**
+  @addtogroup Euclidean
+  @{
+ */
+
+/**
+  @brief        32-bit floating point Euclidean distance between two vectors
+  @param[in]    pA         First vector
+  @param[in]    pB         Second vector
+  @param[in]    blockSize  vector length
+  @param[out]   pRes       output result returned here
+  @return       none
+ */
+
+void plp_euclidean_distance_f32s_rv32im(  const float32_t *__restrict__ pSrcA,
+                                          const float32_t *__restrict__ pSrcB,
+                                          uint32_t blockSize,
+                                          float32_t *__restrict__ pRes) {
+  float32_t result = 0.0f;
+  float32_t accum = 0.0f, tmp;
+  while(blockSize > 0)
+     {
+        tmp = (float32_t)*pSrcA++ - (float32_t)*pSrcB++;
+        accum += tmp*tmp;
+        blockSize --;
+     }
+     plp_sqrt_f32(&accum,pRes);
+}
+
+/**
+   @} end of Euclidean group
+*/

--- a/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_f32s_xpulpv2.c
+++ b/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_f32s_xpulpv2.c
@@ -1,0 +1,74 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_euclidean_distance_f32p_xpulpv2.c
+ * Description:  32-bit floating point Euclidean distance kernel for RV32IM
+ *
+ * $Date:        15. March 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup Euclidean distance
+  Euclidean distance
+ */
+
+/**
+  @addtogroup Euclidean
+  @{
+ */
+
+/**
+  @brief        32-bit floating point Euclidean distance between two vectors
+  @param[in]    pA         First vector
+  @param[in]    pB         Second vector
+  @param[in]    blockSize  vector length
+  @param[out]   pRes       output result returned here
+  @return       none
+ */
+
+void plp_euclidean_distance_f32s_xpulpv2( const float32_t *__restrict__ pSrcA,
+                                          const float32_t *__restrict__ pSrcB,
+                                          uint32_t blockSize,
+                                          float32_t *__restrict__ pRes) {
+
+  float32_t result = 0.0f;
+  float32_t accum = 0.0f, tmp;
+  while(blockSize > 0)
+     {
+        tmp = (float32_t)*pSrcA++ - (float32_t)*pSrcB++;
+        accum += tmp*tmp;
+        blockSize --;
+     }
+     plp_sqrt_f32(&accum, pRes);
+}
+
+/**
+   @} end of Euclidean group
+*/

--- a/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q16s_rv32im.c
+++ b/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q16s_rv32im.c
@@ -1,0 +1,110 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_euclidean_distance_q16s_rv32im.c
+ * Description:  16-bit fixed point Euclidean distance kernel for RV32IM
+ *
+ * $Date:        21 mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2019 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup Euclidean distance
+  Euclidean distance
+ */
+
+/**
+  @addtogroup Euclidean
+  @{
+ */
+
+/**
+  @brief Euclidean distance of 16-bit fixed point vectors kernel for RV32IM extension.
+  @param[in]  pSrcA      points to the first input vector [16 bit]
+  @param[in]  pSrcB      points to the second input vector [16 bit]
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits  decimal point for right shift
+  @param[out] pRes     output result returned here [32 bit]
+  @return     none
+
+  @par Exploiting SIMD instructions
+  When the ISA supports, the 16 bit values are packed two by two into 32 bit vectors and then the
+  two dot products are performed simultaneously on 32 bit vectors, with 32 bit accumulator. RV32IM
+  doesn't support SIMD. For SIMD, check out other ISA extensions (e.g. XPULPV2).
+ */
+
+void plp_euclidean_distance_q16s_rv32im(const int16_t *__restrict__ pSrcA,
+                              const int16_t *__restrict__ pSrcB,
+                              uint32_t blockSize,
+                              uint32_t fracBits,
+                              int32_t *__restrict__ pRes) {
+    uint32_t blkCnt; /* Loop counter */
+    int32_t sum = 0; /* Temporary return variable */
+
+#if defined(PLP_MATH_LOOPUNROLL)
+
+    for (blkCnt = 0; blkCnt < (blockSize >> 2); blkCnt++) {
+        int32_t tmp1, tmp2, tmp3, tmp4;
+        tmp1 = (*pSrcA++) - (*pSrcB++);
+        tmp2 = (*pSrcA++) - (*pSrcB++);
+        tmp3 = (*pSrcA++) - (*pSrcB++);
+        tmp4 = (*pSrcA++) - (*pSrcB++);
+        sum += (tmp1*tmp1) >> fracBits;
+        sum += (tmp2*tmp2) >> fracBits;
+        sum += (tmp3*tmp3) >> fracBits;
+        sum += (tmp4*tmp4) >> fracBits;
+    }
+
+    for (blkCnt = 0; blkCnt < (blockSize % 4U); blkCnt++) {
+        int32_t tmp;
+        tmp = (*pSrcA++) - (*pSrcB++);
+        sum += (tmp*tmp) >> fracBits;
+    }
+
+#else // PLP_MATH_LOOPUNROLL
+
+    for (blkCnt = 0; blkCnt < blockSize; blkCnt++) {
+        int32_t tmp;
+        tmp = (*pSrcA++) - (*pSrcB++);
+        sum += (tmp*tmp) >> fracBits;
+    }
+
+#endif // PLP_MATH_LOOPUNROLL
+
+    plp_sqrt_q32(&sum, fracBits, pRes);
+}
+
+/**
+   @} end of Euclidean group
+*/

--- a/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q16s_xpulpv2.c
+++ b/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q16s_xpulpv2.c
@@ -1,0 +1,116 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_euclidean_distance_q16s_xpulpv2.c
+ * Description:  16-bit fixed point vectorized Euclidean distance for XPULPV2
+ *
+ * $Date:        21. Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2019 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup Euclidean distance
+  Euclidean distance
+ */
+
+/**
+  @addtogroup Euclidean
+  @{
+ */
+
+/**
+  @brief Euclidean distance of 16-bit fixed point vectors kernel for XPULPV2.
+  @param[in]  pSrcA      points to the first input vector [16 bit]
+  @param[in]  pSrcB      points to the second input vector [16 bit]
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits  decimal point for right shift
+  @param[out] pRes     output result returned here [32 bit]
+  @return     none
+
+  @par Exploiting SIMD instructions
+  The 16 bit values are packed two by two into 32 bit vectors and then the sums and prducts are
+  performed simultaneously on 32 bit vectors, with 32 bit accumulator.
+ */
+
+void plp_euclidean_distance_q16s_xpulpv2(const int16_t *__restrict__ pSrcA,
+                               const int16_t *__restrict__ pSrcB,
+                               uint32_t blockSize,
+                               uint32_t fracBits,
+                               int32_t *__restrict__ pRes) {
+
+    uint32_t blkCnt, tmpBS, remBS; /* Loop counter, temporal BlockSize */
+    int32_t sum = 0;
+    //  int32_t sum1 = 0, sum2 = 0;                          /* Temporary return variable */
+
+#if defined(PLP_MATH_LOOPUNROLL)
+
+    tmpBS = (blockSize >> 2);
+
+    for (blkCnt = 0; blkCnt < tmpBS; blkCnt++) {
+
+        v2s a0 = *((v2s *)((void *)(pSrcA + 4 * blkCnt)));
+        v2s b0 = *((v2s *)((void *)(pSrcB + 4 * blkCnt)));
+        v2s a1 = *((v2s *)((void *)(pSrcA + 4 * blkCnt + 2)));
+        v2s b1 = *((v2s *)((void *)(pSrcB + 4 * blkCnt + 2)));
+        a0 = __SUB2(a0, b0);
+        a1 = __SUB2(a1, b1);        
+        int32_t tmp0 = __DOTP2(a0, a0);
+        int32_t tmp1 = __DOTP2(a1, a1);
+        sum += __ADDROUNDNORM_REG(tmp0, tmp1, fracBits);
+    }
+
+    remBS = (blockSize % 4U);
+
+    for (blkCnt = 0; blkCnt < remBS; blkCnt++) {
+        int16_t a = *(pSrcA + 4 * tmpBS + blkCnt);
+        int16_t b = *(pSrcB + 4 * tmpBS + blkCnt);
+        int16_t tmp = a - b;
+        sum += __ROUNDNORM_REG(tmp*tmp, fracBits);
+    }
+
+#else // PLP_MATH_LOOPUNROLL
+
+    for (blkCnt = 0; blkCnt < blockSize; blkCnt++) {
+        int16_t tmp = *(pSrcA ++) - *(pSrcB ++);
+        sum += __ROUNDNORM_REG(tmp*tmp, fracBits);
+    }
+
+#endif // PLP_MATH_LOOPUNROLL
+
+    plp_sqrt_q32(&sum, fracBits, pRes);
+}
+
+/**
+   @} end of BasicDotProdKernels group
+*/

--- a/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q32p_xpulpv2.c
+++ b/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q32p_xpulpv2.c
@@ -1,0 +1,100 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_euclidean_distance_q32p_xpulpv2.c
+ * Description:  32-bit integer scalar Euclidean distance for XPULPV2 with interleaved access
+ *
+ * $Date:        17. Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup Euclidean distance
+  Euclidean distance
+ */
+
+/**
+  @addtogroup Euclidean
+  @{
+ */
+
+/**
+  @brief          Parallel euclidean distance with interleaved access 32-bit fixed point vectors.
+                  vectors kernel for XPULPV2 extension.
+  @param[in]  S   points to the instance structure for integer parallel Euclidean distance
+  @return         none
+ */
+
+void plp_euclidean_distance_q32p_xpulpv2(void *S) {
+
+    int core_id = hal_core_id();
+    uint32_t blkCnt;
+    int32_t sum = 0;
+    
+    uint32_t blkSizePE = ((plp_euclidean_distance_instance_q32 *)S)->blkSizePE;
+    int32_t *pSrcA = (int32_t *)(((plp_euclidean_distance_instance_q32 *)S)->pSrcA)+ hal_core_id()*blkSizePE;
+    int32_t *pSrcB = (int32_t *)(((plp_euclidean_distance_instance_q32 *)S)->pSrcB)+ hal_core_id()*blkSizePE;
+    uint32_t nPE = ((plp_euclidean_distance_instance_q32 *)S)->nPE;
+    uint32_t fracBits = ((plp_euclidean_distance_instance_q32 *)S)->fracBits;
+    int32_t *resBufferPE = &(((plp_euclidean_distance_instance_q32 *)S)->resBuffer[hal_core_id()]);
+
+#if defined(PLP_MATH_LOOPUNROLL)
+
+    for (blkCnt = 0; blkCnt < blkSizePE - 1; blkCnt += 2) {
+        int32_t tmp0 = pSrcA[blkCnt] - pSrcB[blkCnt];
+        int32_t tmp1 = pSrcA[blkCnt + 1] - pSrcB[blkCnt + 1];
+        sum += __ADDROUNDNORM_REG(tmp0*tmp0, tmp1*tmp1, fracBits);
+    }
+
+    while (blkCnt != blkSizePE) {
+        int32_t tmp = pSrcA[blkCnt++] - pSrcB[blkCnt++];
+        sum += __ROUNDNORM_REG(tmp*tmp, fracBits);
+    }
+
+#else // PLP_MATH_LOOPUNROLL
+
+    for (blkCnt = 0; blkCnt < blkSizePE; blkCnt++) {
+        int32_t tmp = pSrcA[blkCnt] - pSrcB[blkCnt];
+        sum += __ROUNDNORM_REG(tmp*tmp, fracBits);
+    }
+
+#endif // PLP_MATH_LOOPUNROLL
+
+    *resBufferPE = sum;
+
+}
+
+/**
+   @} end of Euclidean group
+*/

--- a/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q32s_rv32im.c
+++ b/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q32s_rv32im.c
@@ -1,0 +1,106 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_euclidean_distance_q32s_rv32im.c
+ * Description:  32-bit fixed-point Euclidean distance kernel for RV32IM
+ *
+ * $Date:        17. Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup Euclidean distance
+  Euclidean distance
+ */
+
+/**
+  @addtogroup Euclidean
+  @{
+ */
+
+/**
+  @brief      Euclidean distance of 32-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_euclidean_distance_q32s_rv32im(    const int32_t *__restrict__ pSrcA,
+                                            const int32_t *__restrict__ pSrcB,
+                                            uint32_t blockSize,
+                                            uint32_t fracBits,
+                                            int32_t *__restrict__ pRes) {
+    uint32_t blkCnt; /* Loop counter */
+    int32_t sum = 0; /* Temporary return variable */
+
+#if defined(PLP_MATH_LOOPUNROLL)
+
+    for (blkCnt = 0; blkCnt < (blockSize >> 1); blkCnt++) {
+        int32_t tmp1, tmp2, tmp3, tmp4;
+        tmp1 = (*pSrcA++) - (*pSrcB++);
+        tmp2 = (*pSrcA++) - (*pSrcB++);
+        //tmp3 = (*pSrcA++) - (*pSrcB++);
+        //tmp4 = (*pSrcA++) - (*pSrcB++);
+        sum += (tmp1*tmp1) >> fracBits;
+        sum += (tmp2*tmp2) >> fracBits;
+        //sum += (tmp3*tmp3) >> fracBits;
+        //sum += (tmp4*tmp4) >> fracBits;
+    }
+
+    for (blkCnt = 0; blkCnt < (blockSize % 2U); blkCnt++) {
+        int32_t tmp;
+        tmp = (*pSrcA++) - (*pSrcB++);
+        sum += (tmp*tmp) >> fracBits;
+    }
+
+#else // PLP_MATH_LOOPUNROLL
+
+    for (blkCnt = 0; blkCnt < blockSize; blkCnt++) {
+        int32_t tmp;
+        tmp = (*pSrcA++) - (*pSrcB++);
+        sum += (tmp*tmp) >> fracBits;
+    }
+
+#endif // PLP_MATH_LOOPUNROLL
+    
+    plp_sqrt_q32(&sum, fracBits, pRes);
+
+}
+
+/**
+   @} end of Euclidean group
+*/

--- a/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q32s_xpulpv2.c
+++ b/src/DistanceFunctions/plp_euclidean_distance/kernels/plp_euclidean_distance_q32s_xpulpv2.c
@@ -1,0 +1,108 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_euclidean_distance_q32s_xpulpv2.c
+ * Description:  32-bit fixed-point Euclidean distance for XPULPV2
+ *
+ * $Date:        17. Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup Euclidean distance
+  Euclidean distance
+ */
+
+/**
+  @addtogroup Euclidean
+  @{
+ */
+
+/**
+  @brief      Euclidean distance of 32-bit fixed point vectors kernel for XPULPV2 extension.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes       output result returned here
+  @return     none
+ */
+
+void plp_euclidean_distance_q32s_xpulpv2(   const int32_t *__restrict__ pSrcA,
+                                            const int32_t *__restrict__ pSrcB,
+                                            uint32_t blockSize,
+                                            uint32_t fracBits,
+                                            int32_t *__restrict__ pRes) {
+    
+    uint32_t blkCnt, tmpBS; /* Loop counter, temporal BlockSize */
+    int32_t sum = 0;        //, sum1 =0;                          /* Temporary return variable */
+    // int32_t prod=0;
+    // int32_t deci = deciPoint;
+
+#if defined(PLP_MATH_LOOPUNROLL)
+
+    tmpBS = (blockSize >> 1);
+
+    for (blkCnt = 0; blkCnt < tmpBS; blkCnt++) {
+
+        int32_t tmp0 = (*pSrcA++) - (*pSrcB++);
+        int32_t tmp1 = (*pSrcA++) - (*pSrcB++);
+        //int32_t tmp2 = (*pSrcA++) - (*pSrcB++);
+        //int32_t tmp3 = (*pSrcA++) - (*pSrcB++);
+        sum += __ADDROUNDNORM_REG(tmp0*tmp0, tmp1*tmp1, fracBits);
+        //sum += __ADDROUNDNORM_REG(tmp2*tmp2, tmp3*tmp3, fracBits);
+
+    }
+
+    for (blkCnt = 0; blkCnt < (blockSize % 2U); blkCnt++) {
+        int32_t tmp = (*pSrcA++) - (*pSrcB++);
+        sum += __ADDROUNDNORM_REG(tmp*tmp, 0, fracBits);
+    }
+
+#else // PLP_MATH_LOOPUNROLL
+
+    for (blkCnt = 0; blkCnt < blockSize; blkCnt++) {
+        int32_t tmp = (*pSrcA++) - (*pSrcB++);
+        sum += __ADDROUNDNORM_REG(tmp*tmp, 0, fracBits);
+    }
+
+#endif // PLP_MATH_LOOPUNROLL
+
+    plp_sqrt_q32(&sum, fracBits, pRes);
+}
+
+
+/**
+   @} end of Euclidean group
+*/

--- a/src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_f32.c
+++ b/src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_f32.c
@@ -1,0 +1,76 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_dot_prod_f32.c
+ * Description:  32-bit float Euclidean distance glue code
+ *
+ * $Date:        8. March 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup Euclidean distance
+  Euclidean distance
+ */
+
+/**
+  @addtogroup Euclidean
+  @{
+ */
+
+/**
+  @brief        Glue code for Euclidean distance between 32-bit float vectors.
+  @param[in]    pSrcA         First vector
+  @param[in]    pSrcB         Second vector
+  @param[in]    blockSize     vector length
+  @return       none
+ */
+
+
+void plp_euclidean_distance_f32(  const float32_t *__restrict__ pSrcA,
+                                  const float32_t *__restrict__ pSrcB,
+                                  uint32_t blockSize,
+                                  float32_t *__restrict__ pRes) {
+
+    if (hal_cluster_id() == ARCHI_FC_CID) {
+        //printf("Note: FC doesn't have FPU\n");
+        plp_euclidean_distance_f32s_rv32im(pSrcA, pSrcB, blockSize, pRes);
+    } else {
+        plp_euclidean_distance_f32s_xpulpv2(pSrcA, pSrcB, blockSize, pRes);
+    }
+}
+
+/**
+  @} end of Euclidean group
+ */

--- a/src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_f32_parallel.c
+++ b/src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_f32_parallel.c
@@ -1,0 +1,104 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_euclidean_distance_f32_parallel.c
+ * Description:  32-bit float parallel euclidean distance glue code
+ *
+ * $Date:        01. Jan 2020
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup Euclidean distance
+  Euclidean distance
+ */
+
+/**
+  @addtogroup Euclidean
+  @{
+ */
+
+/**
+  @brief        Glue code for parallel Euclidean distance between 32-bit float vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  nPE        number of parallel processing units
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_euclidean_distance_f32_parallel( const float32_t *__restrict__ pSrcA,
+                                          const float32_t *__restrict__ pSrcB,
+                                          uint32_t blockSize,
+                                          uint32_t nPE,
+                                          float32_t *__restrict__ pRes) {
+
+    if (hal_cluster_id() == ARCHI_FC_CID) {
+        printf("parallel processing supported only for cluster side\n");
+        return;
+    } else {
+
+        uint32_t i, tmpblkSizePE = blockSize / nPE;
+        float32_t resBuffer[hal_cl_nb_pe_cores()];
+
+        plp_euclidean_distance_instance_f32 S;
+
+        // Initialize the plp_dot_prod_instance
+        S.pSrcA = pSrcA;
+        S.pSrcB = pSrcB;
+        S.blkSizePE = tmpblkSizePE;
+        S.nPE = nPE;
+        S.resBuffer = resBuffer;
+
+        // Fork the dot product to nPE cores (i.e. processing units)
+        hal_cl_team_fork(nPE, plp_euclidean_distance_f32p_xpulpv2, (void *)&S);
+
+        float32_t sum = 0, tmp;
+        for (i = 0; i < nPE; i++) { // not necessary hal_cl_nb_pe_cores()
+            sum += resBuffer[i];
+        }
+        for (i = (tmpblkSizePE)*nPE; i < blockSize; i++) {
+            tmp = pSrcA[i] - pSrcB[i];
+            sum += tmp*tmp;
+        }
+
+        plp_sqrt_f32(&sum,pRes);
+
+    }
+}
+
+/**
+  @} end of Euclidean group
+ */

--- a/src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_q16.c
+++ b/src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_q16.c
@@ -1,0 +1,77 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_euclidean_distance_q32.c
+ * Description:  32-bit fixed-point Euclidean distance glue code
+ *
+ * $Date:        21. Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup Euclidean distance
+  Euclidean distance
+ */
+
+/**
+  @addtogroup Euclidean
+  @{
+ */
+
+/**
+  @brief Glue code for euclidean distance of 16-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_euclidean_distance_q16(  const int16_t *__restrict__ pSrcA,
+                                  const int16_t *__restrict__ pSrcB,
+                                  uint16_t blockSize,
+                                  uint16_t fracBits,
+                                  int32_t *__restrict__ pRes) {
+
+    if (hal_cluster_id() == ARCHI_FC_CID) {
+        plp_euclidean_distance_q16s_rv32im(pSrcA, pSrcB, blockSize, fracBits, pRes);
+    } else {
+        plp_euclidean_distance_q16s_xpulpv2(pSrcA, pSrcB, blockSize, fracBits, pRes);
+    }
+}
+
+/**
+  @} end of Euclidean group
+ */

--- a/src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_q32.c
+++ b/src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_q32.c
@@ -1,0 +1,77 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_euclidean_distance_q32.c
+ * Description:  32-bit fixed-point Euclidean distance glue code
+ *
+ * $Date:        17. Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup Euclidean distance
+  Euclidean distance
+ */
+
+/**
+  @addtogroup Euclidean
+  @{
+ */
+
+/**
+  @brief Glue code for euclidean distance of 32-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_euclidean_distance_q32(  const int32_t *__restrict__ pSrcA,
+                                  const int32_t *__restrict__ pSrcB,
+                                  uint32_t blockSize,
+                                  uint32_t fracBits,
+                                  int32_t *__restrict__ pRes) {
+
+    if (hal_cluster_id() == ARCHI_FC_CID) {
+        plp_euclidean_distance_q32s_rv32im(pSrcA, pSrcB, blockSize, fracBits, pRes);
+    } else {
+        plp_euclidean_distance_q32s_xpulpv2(pSrcA, pSrcB, blockSize, fracBits, pRes);
+    }
+}
+
+/**
+  @} end of Euclidean group
+ */

--- a/src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_q32_parallel.c
+++ b/src/DistanceFunctions/plp_euclidean_distance/plp_euclidean_distance_q32_parallel.c
@@ -1,0 +1,101 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_euclidean_distance_q32_parallel.c
+ * Description:  32-bit fixed-point Euclidean distance glue code
+ *
+ * $Date:        17. Mar 2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+  @ingroup DistanceFunctions
+ */
+
+/**
+  @defgroup Euclidean distance
+  Euclidean distance
+ */
+
+/**
+  @addtogroup Euclidean
+  @{
+ */
+
+/**
+  @brief Glue code for parallel Euclidean distance of 32-bit fixed point vectors.
+  @param[in]  pSrcA      points to the first input vector
+  @param[in]  pSrcB      points to the second input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[in]  nPE        number of parallel processing units
+  @param[out] pRes     output result returned here
+  @return     none
+ */
+
+void plp_euclidean_distance_q32_parallel(   const int32_t *__restrict__ pSrcA,
+                                            const int32_t *__restrict__ pSrcB,
+                                            uint32_t blockSize,
+                                            uint32_t fracBits,
+                                            uint32_t nPE,
+                                            uint32_t *__restrict__ pRes) {
+
+    if (hal_cluster_id() == ARCHI_FC_CID) {
+        printf("parallel processing supported only for cluster side\n");
+        return;
+    } else {
+
+        uint32_t i;
+        int32_t resBuffer[hal_cl_nb_pe_cores()];
+
+        plp_euclidean_distance_instance_q32 S;
+
+        // Initialize the plp_dot_prod_instance
+        S.pSrcA = pSrcA;
+        S.pSrcB = pSrcB;
+        S.blkSizePE = blockSize/nPE;
+        S.fracBits = fracBits;
+        S.nPE = nPE;
+        S.resBuffer = resBuffer;
+
+        // Fork the dot product to nPE cores (i.e. processing units)
+        hal_cl_team_fork(nPE, plp_euclidean_distance_q32p_xpulpv2, (void *)&S);
+        int32_t sum = 0;
+        for (i = 0; i < nPE; i++) {
+            sum += resBuffer[i];
+        }
+        plp_sqrt_q32(&sum, fracBits, pRes);
+
+    }
+}
+
+/**
+  @} end of Euclidean group
+ */

--- a/src/FastMathFunctions/kernels/plp_sqrt_f32s_rv32im.c
+++ b/src/FastMathFunctions/kernels/plp_sqrt_f32s_rv32im.c
@@ -1,0 +1,79 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_sqrt_f32s_xpulpv2.c
+ * Description:  32-Bit floating point square root kernel
+ *
+ * $Date:        21 Mar 2022
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+   @ingroup sqrt
+*/
+
+/**
+   @defgroup sqrtKernels Sqrt Kernels
+*/
+
+/**
+   @addtogroup sqrtKernels
+   @{
+*/
+
+/**
+   @brief         Square root of a 32-bit floating point number for RV32IM.
+   @param[in]     pSrc    points to the input vector
+   @param[out]    pRes    Square root returned here
+   @return        none
+*/
+
+void plp_sqrt_f32s_rv32im(const float *__restrict__ pSrc, float *__restrict__ pRes) {
+
+    const float threehalfs = 1.5f;
+    float x2, y;
+
+    union {
+        float f;
+        int32_t i;
+    } conv;
+
+    if (*pSrc > 0) {
+        /* fast inverse square root with proper type punning */
+        x2 = *pSrc * 0.5f;
+        conv.f = *pSrc;
+        conv.i = 0x5f3759df - (conv.i >> 1); /* evil floating point bit level hacking */
+        y = conv.f;
+        y = y * (threehalfs - (x2 * y * y)); /* newton 1st iter */
+        y = y * (threehalfs - (x2 * y * y)); /* newton 2nd iter */
+        *pRes = *pSrc * y;                   /* to square root */
+    } else {
+        *pRes = 0.f;
+    }
+}

--- a/src/StatisticsFunctions/kernels/plp_power_f32p_xpulpv2.c
+++ b/src/StatisticsFunctions/kernels/plp_power_f32p_xpulpv2.c
@@ -1,0 +1,84 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_power_f32p_xpulpv2.c
+ * Description:  Calculates the sum of squares on XPULPV2 cores
+ *
+ * $Date:        22.03.2022
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+/**
+   @ingroup groupStat
+*/
+
+/**
+   @defgroup powerKernels Power Kernels
+   Calculates the sum of squares of the input vector.
+   There are separate functions for floating point, integer, and fixed point 32- 16- 8-bit data
+   types. For lower precision integers (16- and 8-bit), functions exploiting SIMD instructions are
+   provided.
+
+   The naming scheme of the functions follows the following pattern (for example plp_dot_prod_i32s):
+   <pre>
+   \<pulp\> _ \<function name\> _ \<data type\> \<precision\> \<method\> _ \<isa extension\>, with
+
+   data type = {f, i, q} respectively for floats, integers, fixed points
+
+   precision = {32, 16, 8} bits
+
+   method = {s, p} respectively meaning single core or parallel multicore implementation.
+
+   isa extension = rv32im, xpulpv2, etc. of which rv32im is the most general one.
+
+   </pre>
+
+*/
+
+/**
+   @addtogroup powerKernels
+   @{
+*/
+
+/**
+   @brief          Parallel sum of squares of a 32-bit float vector for XPULPV2 extension.
+   @param[in]  S   points to the instance structure for floating-point parallel power
+   @return         none
+*/
+
+void plp_power_f32p_xpulpv2(void* S) {
+
+    float32_t *pSrc = (float32_t *)(((plp_power_instance_f32 *)S)->pSrc) + hal_core_id();
+    uint32_t blkSizePE = ((plp_power_instance_f32 *)S)->blkSizePE;
+    uint32_t nPE = ((plp_power_instance_f32 *)S)->nPE;
+    float32_t *resBufferPE = &(((plp_power_instance_f32 *)S)->resBuffer[hal_core_id()]);
+
+    uint32_t blkCnt = 0;
+    float32_t accum = 0.0f, tmp;
+    for (blkCnt = 0; blkCnt < blkSizePE; blkCnt++) {
+        tmp = pSrc[nPE * blkCnt];
+        accum += tmp*tmp;
+    }
+    *resBufferPE = accum;
+}

--- a/src/StatisticsFunctions/kernels/plp_power_f32s_rv32im.c
+++ b/src/StatisticsFunctions/kernels/plp_power_f32s_rv32im.c
@@ -1,0 +1,104 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_power_f32s_rv32im.c
+ * Description:  Calculates the sum of squares on XPULPV2 cores
+ *
+ * $Date:        21. Mar 2022
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+/**
+   @ingroup groupStat
+*/
+
+/**
+   @defgroup powerKernels Power Kernels
+   Calculates the sum of squares of the input vector.
+   There are separate functions for floating point, integer, and fixed point 32- 16- 8-bit data
+   types. For lower precision integers (16- and 8-bit), functions exploiting SIMD instructions are
+   provided.
+
+   The naming scheme of the functions follows the following pattern (for example plp_dot_prod_i32s):
+   <pre>
+   \<pulp\> _ \<function name\> _ \<data type\> \<precision\> \<method\> _ \<isa extension\>, with
+
+   data type = {f, i, q} respectively for floats, integers, fixed points
+
+   precision = {32, 16, 8} bits
+
+   method = {s, p} respectively meaning single core or parallel multicore implementation.
+
+   isa extension = rv32im, xpulpv2, etc. of which rv32im is the most general one.
+
+   </pre>
+
+*/
+
+/**
+   @addtogroup powerKernels
+   @{
+*/
+
+/**
+   @brief         Sum of squares of a 32-bit float vector for RV32IM.
+   @param[in]     pSrc       points to the input vector
+   @param[in]     blockSize  number of samples in input vector
+   @param[out]    pRes    sum of squares returned here
+   @return        none
+*/
+
+void plp_power_f32s_rv32im(const float *__restrict__ pSrc,
+                            uint32_t blockSize,
+                            float *__restrict__ pRes) {
+
+    uint32_t blkCnt = 0;
+    float x1, x2;
+    float sum = 0;
+
+#if defined(PLP_MATH_LOOPUNROLL)
+
+    for (blkCnt = 0; blkCnt < (blockSize >> 1); blkCnt++) {
+        x1 = *pSrc++;
+        x2 = *pSrc++;
+        sum += x1 * x1;
+        sum += x2 * x2;
+    }
+
+    if (blockSize % 2 == 1) {
+        x1 = *pSrc++;
+        sum += x1 * x1;
+    }
+
+#else
+
+    for (blkCnt = 0; blkCnt < blockSize; blkCnt++) {
+        x1 = *pSrc++;
+        sum += x1 * x1;
+    }
+
+#endif
+
+    *pRes = sum;
+}

--- a/src/StatisticsFunctions/kernels/plp_power_q32p_xpulpv2.c
+++ b/src/StatisticsFunctions/kernels/plp_power_q32p_xpulpv2.c
@@ -1,0 +1,119 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_power_q32p_xpulpv2.c
+ * Description:  Calculates the sum of squares on XPULPV2 cores
+ *
+ * $Date:        22.03.2022
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2020 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plp_math.h"
+
+/**
+   @ingroup groupStat
+*/
+
+/**
+   @defgroup powerKernels Power Kernels
+   Calculates the sum of squares of the input vector.
+   There are separate functions for floating point, integer, and fixed point 32- 16- 8-bit data
+   types. For lower precision integers (16- and 8-bit), functions exploiting SIMD instructions are
+   provided.
+
+   The naming scheme of the functions follows the following pattern (for example plp_dot_prod_i32s):
+   <pre>
+   \<pulp\> _ \<function name\> _ \<data type\> \<precision\> \<method\> _ \<isa extension\>, with
+
+   data type = {f, i, q} respectively for floats, integers, fixed points
+
+   precision = {32, 16, 8} bits
+
+   method = {s, p} respectively meaning single core or parallel multicore implementation.
+
+   isa extension = rv32im, xpulpv2, etc. of which rv32im is the most general one.
+
+   </pre>
+
+*/
+
+/**
+   @addtogroup powerKernels
+   @{
+*/
+
+/**
+   @brief          Parallel sum of squares of a 32-bit float vector for XPULPV2 extension.
+   @param[in]  S   points to the instance structure for floating-point parallel power
+   @return         none
+*/
+
+void plp_power_q32p_xpulpv2(void* S) {
+
+    int core_id = hal_core_id();
+    plp_power_instance_q32 *args = (plp_power_instance_q32 *)S;
+
+    int32_t *pSrc = (int32_t *)(args->pSrc);
+    uint32_t blkSizePE = args->blkSizePE;
+    uint32_t deciPoint = args->deciPoint;
+    uint32_t nPE = args->nPE;
+    int32_t *resBufferPE = &(args->resBuffer[core_id]);
+
+    uint32_t blkSize = (blkSizePE / nPE) & 0xFFFFFFFE; // the and makes sure the block size is even
+    pSrc += core_id * blkSize;
+    // set the block size for the last core
+    if (core_id == nPE - 1) {
+        blkSize = blkSizePE - (nPE - 1) * blkSize;
+    }
+
+    if (blkSize == 0) {
+        *resBufferPE = 0;
+        return;
+    }
+
+    int32_t i, sum = 0;
+
+#if defined(PLP_MATH_LOOPUNROLL)
+
+    for (i = 0; i < blkSize - 1; i += 2) {
+      //int32_t x0 = pSrc[i] * pSrc[i];
+      //int32_t x1 = pSrc[i + 1] * pSrc[i + 1];
+      //sum += __ADDROUNDNORM_REG(x0, x1, deciPoint);
+      sum += (pSrc[i] * pSrc[i])>>deciPoint;
+      sum += (pSrc[i + 1] * pSrc[i + 1])>>deciPoint;
+    }
+
+    while (i != blkSize) {
+        sum += pSrc[i] * pSrc[i] >> deciPoint;
+        i++;
+    }
+
+#else // PLP_MATH_LOOPUNROLL*/
+
+    for (i = 0; i < blkSize; i++) {
+        sum += (pSrc[i] * pSrc[i] >> deciPoint);
+    }
+
+#endif // PLP_MATH_LOOPUNROLL
+
+    *resBufferPE = sum;
+}

--- a/src/StatisticsFunctions/kernels/plp_power_q32p_xpulpv2.c
+++ b/src/StatisticsFunctions/kernels/plp_power_q32p_xpulpv2.c
@@ -74,7 +74,7 @@ void plp_power_q32p_xpulpv2(void* S) {
 
     int32_t *pSrc = (int32_t *)(args->pSrc);
     uint32_t blkSizePE = args->blkSizePE;
-    uint32_t deciPoint = args->deciPoint;
+    uint32_t deciPoint = args->fracBits;
     uint32_t nPE = args->nPE;
     int32_t *resBufferPE = &(args->resBuffer[core_id]);
 

--- a/src/StatisticsFunctions/plp_power_f32.c
+++ b/src/StatisticsFunctions/plp_power_f32.c
@@ -72,7 +72,7 @@
 void plp_power_f32(const float *__restrict__ pSrc, uint32_t blockSize, float *__restrict__ pRes) {
 
     if (hal_cluster_id() == ARCHI_FC_CID) {
-        *pRes = -1;
+        plp_power_f32s_rv32im(pSrc, blockSize, pRes);
     } else {
         plp_power_f32s_xpulpv2(pSrc, blockSize, pRes);
     }

--- a/src/StatisticsFunctions/plp_power_f32_parallel.c
+++ b/src/StatisticsFunctions/plp_power_f32_parallel.c
@@ -1,0 +1,119 @@
+/* =====================================================================
+ * Project:      PULP DSP Library
+ * Title:        plp_power_q32_parallel.c
+ * Description:  32-bit integer parallel power glue code
+ *
+ * $Date:        22.03.2022
+ * $Revision:    V0
+ *
+ * Target Processor: PULP cores
+ * ===================================================================== */
+/*
+ * Copyright (C) 2022 ETH Zurich and University of Bologna.
+ *
+ * Author: Marco Bertuletti, ETH Zurich
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Notice: project inspired by ARM CMSIS DSP and parts of source code
+ * ported and adopted for RISC-V PULP platform from ARM CMSIS DSP
+ * released under Copyright (C) 2010-2019 ARM Limited or its affiliates
+ * with Apache-2.0.
+ */
+
+#include "plp_math.h"
+
+/**
+   @ingroup groupStats
+*/
+
+/**
+   @defgroup power Power
+   Calculates the sum of squares of the input vector.
+   There are separate functions for floating point, integer, and fixed point 32- 16- 8-bit data
+   types. For lower precision integers (16- and 8-bit), functions exploiting SIMD instructions are
+   provided.
+
+   The naming scheme of the functions follows the following pattern (for example plp_dot_prod_i32s):
+   <pre>
+   \<pulp\> _ \<function name\> _ \<data type\> \<precision\> \<method\> _ \<isa extension\>, with
+
+   data type = {f, i, q} respectively for floats, integers, fixed points
+
+   precision = {32, 16, 8} bits
+
+   method = {s, p} respectively meaning single core or parallel multicore implementation.
+
+   isa extension = rv32im, xpulpv2, etc. of which rv32im is the most general one.
+
+   </pre>
+
+*/
+
+/**
+   @addtogroup power
+   @{
+*/
+
+/**
+  @brief Glue code for parallel power of 32-bit floating point vectors.
+  @param[in]  pSrc       points to the input vector
+  @param[in]  blockSize  number of samples in each vector
+  @param[in]  fracBits   number of fixed point fractional bits
+  @param[in]  nPE        number of parallel processing units
+  @param[out] pRes       output result returned here
+  @return     none
+ */
+
+void plp_power_f32_parallel(    const float32_t *__restrict__ pSrc,
+                                uint32_t blockSize,
+                                uint32_t nPE,
+                                float32_t *__restrict__ pRes) {
+    
+    if (hal_cluster_id() == ARCHI_FC_CID) {
+        printf("parallel processing supported only for cluster side\n");
+        return;
+    } else {
+
+        uint32_t i, tmpblkSizePE = blockSize / nPE;
+        float32_t resBuffer[hal_cl_nb_pe_cores()];
+
+        plp_power_instance_f32 S;
+
+        // Initialize the plp_power_instance
+        S.pSrc = pSrc;
+        S.blkSizePE = tmpblkSizePE;
+        S.nPE = nPE;
+        S.resBuffer = resBuffer;
+
+        // Fork the dot product to nPE cores (i.e. processing units)
+        hal_cl_team_fork(nPE, plp_power_f32p_xpulpv2, (void *)&S);
+
+        float32_t sum = 0, tmp;
+        for (i = 0; i < nPE; i++) { // not necessary hal_cl_nb_pe_cores()
+            sum += resBuffer[i];
+        }
+        for (i = (tmpblkSizePE)*nPE; i < blockSize; i++) {
+            tmp = pSrc[i];
+            sum += tmp*tmp;
+        }
+        *pRes = sum;
+    }
+
+}
+
+/**
+  @} end of power group
+ */

--- a/src/StatisticsFunctions/plp_power_q32_parallel.c
+++ b/src/StatisticsFunctions/plp_power_q32_parallel.c
@@ -96,7 +96,7 @@ void plp_power_q32_parallel(    const int32_t *__restrict__ pSrc,
         // Initialize the plp_dot_prod_instance
         S.pSrc = pSrc;
         S.blkSizePE = blockSize;
-        S.deciPoint = deciPoint;
+        S.fracBits = deciPoint;
         S.nPE = nPE;
         S.resBuffer = resBuffer;
 

--- a/test/mrWolf/cosine_distance/test_lib/gen_stimuli.py
+++ b/test/mrWolf/cosine_distance/test_lib/gen_stimuli.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import numpy as np
+import math
+
+##################
+# compute_result #
+##################
+
+
+def compute_result(result_parameter, inputs, env, fix_point):
+    """
+    Funciton to generate the expected result of the testcase.
+
+    Arguments
+    ---------
+    result_parameter: Either OutputArgument or ReturnValue (see pulp_dsp_test.py)
+    inputs: Dict mapping name to the Argument, with arg.value, arg.ctype (and arg.length)
+    env: Dict mapping the variable (SweepVariable or DynamicVariable) names to their value.
+    fix_point: None (if no fixpoint is used) or decimal point
+    """
+    if(fix_point == None):
+        fix_point = 0
+    if result_parameter.ctype == 'int32_t':
+        a = inputs['srcA'].value.astype(np.int32)
+        b = inputs['srcB'].value.astype(np.int32)
+        pwra = np.zeros(1, dtype=np.int32)
+        pwrb = np.zeros(1, dtype=np.int32)
+        dotp = np.zeros(1, dtype=np.int32)
+        for xa, xb in zip(a, b):
+            dotp[0] = q_add(dotp[0], (xa*xb) >> fix_point)
+            pwra[0] = q_add(pwra[0], (xa*xa) >> fix_point)
+            pwrb[0] = q_add(pwrb[0], (xb*xb) >> fix_point)
+
+        if pwra[0] > 0:
+            pwra[0] = int(2**(fix_point)*np.sqrt(float(pwra[0])/2**(fix_point)))
+        else:
+            pwra[0] = 0;
+
+        if pwrb[0] > 0:
+            pwrb[0] = int(2**(fix_point)*np.sqrt(float(pwrb[0])/2**(fix_point)))
+        else:
+            pwrb[0] = 0;
+
+        result = 1 - dotp/((pwra*pwrb)>>fix_point)
+                       
+    elif result_parameter.ctype == 'int16_t':
+        a = inputs['srcA'].value.astype(np.int16)
+        b = inputs['srcB'].value.astype(np.int16)
+        pwra = np.zeros(1, dtype=np.int16)
+        pwrb = np.zeros(1, dtype=np.int16)
+        dotp = np.zeros(1, dtype=np.int16)
+        for xa, xb in zip(a, b):
+            dotp[0] = q_add(dotp[0], (xa*xb) >> fix_point)
+            pwra[0] = q_add(pwra[0], (xa*xa) >> fix_point)
+            pwrb[0] = q_add(pwrb[0], (xb*xb) >> fix_point)
+
+        if pwra[0] > 0:
+            pwra[0] = int(2**(fix_point)*np.sqrt(float(pwra[0])/2**(fix_point)))
+        else:
+            pwra[0] = 0;
+
+        if pwrb[0] > 0:
+            pwrb[0] = int(2**(fix_point)*np.sqrt(float(pwrb[0])/2**(fix_point)))
+        else:
+            pwrb[0] = 0;
+
+        result = 1 - dotp/((pwra*pwrb)>>fix_point)
+                    
+    elif result_parameter.ctype == 'int8_t':
+        raise RuntimeError("Int8 not implemented")
+
+    elif result_parameter.ctype == 'float':
+        # for float implementation, it is important to always use float32 for intermediate operations!
+        a = inputs['srcA'].value.astype(np.float32)
+        b = inputs['srcB'].value.astype(np.float32)
+        pwra = np.zeros(1, dtype=np.float32)
+        pwrb = np.zeros(1, dtype=np.float32)
+        dotp = np.zeros(1, dtype=np.float32)
+        for x_a, x_b in zip(a, b):
+            dotp += (x_a*x_b)
+            pwra += np.square(x_a)
+            pwrb += np.square(x_b)
+
+        pwra = np.sqrt(pwra)
+        pwrb = np.sqrt(pwrb)
+        result = np.float32(0)
+        result = 1.0 - dotp/(pwra*pwrb)
+        #result = np.array([res], dtype=np.float32)
+
+    else:
+        raise RuntimeError("Unrecognized result type: %s" % result_parameter.ctype)
+
+    return result
+
+
+######################
+# Fixpoint Functions #
+######################
+
+
+def q_sat(x):
+    if x > 2**31 - 1:
+        return x - 2**32
+    elif x < -2**31:
+        return x + 2**32
+    else:
+        return x
+
+
+def q_add(a, b):
+    return q_sat(a + b)
+
+
+def q_sub(a, b):
+    return q_sat(a - b)
+
+
+def q_mul(a, b, p):
+    return q_roundnorm(a * b, p)
+
+
+def q_roundnorm(a, p):
+    rounding = 1 << (p - 1)
+    return q_sat((a + rounding) >> p)

--- a/test/mrWolf/cosine_distance/test_lib/testset.cfg
+++ b/test/mrWolf/cosine_distance/test_lib/testset.cfg
@@ -59,29 +59,30 @@ from pulp_dsp_test import generate_test
 # sweep variables. Parameter env is a dict, mapping the name of the variable to the value for the
 # specific test.
 
-function_name = 'plp_power'
+function_name = 'plp_cosine_distance'
 
 variables = [
-	SweepVariable('len', [128, 129, 130, 131, 1024]),
-  	SweepVariable('fp', [0, 1, 2, 4, 15], active=lambda v: 'q' in v),
+	SweepVariable('len', [128, 256, 512, 1024]),
+  	SweepVariable('fp', [2], active=lambda v: 'q' in v),
 ]
 
 arguments = [
-	ArrayArgument('pSrc', 'var_type', 'len', None),
-	Argument('blockSize', 'uint32_t', 'len'),
-  	FixPointArgument('deciPoint',  'fp'),
-  	ParallelArgument('nPE', 8),  
-	OutputArgument('pRes', 'ret_type', 1, tolerance=lambda v: 1e-3 if v.startswith('f') else 0),
+	ArrayArgument('srcA', 'var_type', 'len', (-10,10)),
+	ArrayArgument('srcB', 'var_type', 'len', (-10,10)),
+	Argument('length', 'uint32_t', 'len'),
+	FixPointArgument('deciPoint', 'fp'),
+	ParallelArgument('nPE', 8),
+	OutputArgument('res', 'ret_type', 1, tolerance=lambda v: 1e-3 if v.startswith('f') else 3),
 ]
 
 implemented = {
 	'riscy': {
-		'i32': True,
-		'i16': True,
-		'i8':  True,
+		'i32': False,
+		'i16': False,
+		'i8':  False,
 		'q32': True,
 		'q16': True,
-		'q8':  True,
+		'q8':  False,
 		'f32': True,
 		'i32_parallel': False,
 		'i16_parallel': False,
@@ -92,25 +93,15 @@ implemented = {
 		'f32_parallel': True
 	},
 	'ibex': {
-		'i32': True,
-		'i16': True,
-		'i8':  True,
+		'i32': False,
+		'i16': False,
+		'i8':  False,
 		'q32': True,
 		'q16': True,
-		'q8':  True,
+		'q8':  False,
 	}
 }
 
 n_ops = lambda env: env['len']
 
-arg_ret_type = {
-	'i32':   ('int32_t', 'int32_t'),
-	'i16':   ('int16_t', 'int32_t'),
-	'i8':    ('int8_t',  'int32_t'),
-	'q32':   ('int32_t', 'int32_t'),
-	'q16':   ('int16_t', 'int32_t'),
-	'q8':    ('int8_t',  'int32_t'),
-	'float': ('float',   'float')
-}
-
-TestConfig = c = generate_test(function_name, arguments, variables, implemented, use_l1=True, n_ops=n_ops, arg_ret_type=arg_ret_type)
+TestConfig = c = generate_test(function_name, arguments, variables, implemented, use_l1=True, n_ops=n_ops)

--- a/test/mrWolf/euclidean_distance/test_lib/gen_stimuli.py
+++ b/test/mrWolf/euclidean_distance/test_lib/gen_stimuli.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import numpy as np
+import math
+    
+##################
+# compute_result #
+##################
+
+
+def compute_result(result_parameter, inputs, env, fix_point):
+    """
+    Funciton to generate the expected result of the testcase.
+
+    Arguments
+    ---------
+    result_parameter: Either OutputArgument or ReturnValue (see pulp_dsp_test.py)
+    inputs: Dict mapping name to the Argument, with arg.value, arg.ctype (and arg.length)
+    env: Dict mapping the variable (SweepVariable or DynamicVariable) names to their value.
+    fix_point: None (if no fixpoint is used) or decimal point
+    """
+    if(fix_point == None):
+        fix_point = 0
+    if result_parameter.ctype == 'int32_t':
+        a = inputs['srcA'].value.astype(np.int32)
+        b = inputs['srcB'].value.astype(np.int32)
+        result = np.zeros(1, dtype=np.int32)
+        for xa, xb in zip(a, b):
+            tmp = xa - xb;
+            result[0] = q_add(result[0], (tmp*tmp) >> fix_point)
+
+        if result[0] > 0:
+            result[0] = int(2**(fix_point)*np.sqrt(float(result[0])/2**(fix_point)))
+        else:
+            result[0] = 0;
+                       
+    elif result_parameter.ctype == 'int16_t':
+        a = inputs['srcA'].value.astype(np.int16)
+        b = inputs['srcB'].value.astype(np.int16)
+        result = np.zeros(1, dtype=np.int16)
+        for xa, xb in zip(a, b):
+            tmp = xa - xb;
+            result[0] = q_add(result[0], (tmp*tmp) >> fix_point)
+
+        if result[0] > 0:
+            result[0] = int(2**(fix_point)*np.sqrt(float(result[0])/2**(fix_point)))
+        else:
+            result[0] = 0;
+                    
+    elif result_parameter.ctype == 'int8_t':
+        raise RuntimeError("Int8 not implemented")
+
+    elif result_parameter.ctype == 'float':
+        # for float implementation, it is important to always use float32 for intermediate operations!
+        a = inputs['srcA'].value.astype(np.float32)
+        b = inputs['srcB'].value.astype(np.float32)
+        res = np.float32(0)
+        for x_a, x_b in zip(a, b):
+            res += np.square(x_a-x_b)
+        res = np.sqrt(res)
+        result = np.array([res], dtype=np.float32)
+
+    else:
+        raise RuntimeError("Unrecognized result type: %s" % result_parameter.ctype)
+
+    return result
+
+
+######################
+# Fixpoint Functions #
+######################
+
+
+def q_sat(x):
+    if x > 2**31 - 1:
+        return x - 2**32
+    elif x < -2**31:
+        return x + 2**32
+    else:
+        return x
+
+
+def q_add(a, b):
+    return q_sat(a + b)
+
+
+def q_sub(a, b):
+    return q_sat(a - b)
+
+
+def q_mul(a, b, p):
+    return q_roundnorm(a * b, p)
+
+
+def q_roundnorm(a, p):
+    rounding = 1 << (p - 1)
+    return q_sat((a + rounding) >> p)

--- a/test/mrWolf/euclidean_distance/test_lib/testset.cfg
+++ b/test/mrWolf/euclidean_distance/test_lib/testset.cfg
@@ -59,29 +59,30 @@ from pulp_dsp_test import generate_test
 # sweep variables. Parameter env is a dict, mapping the name of the variable to the value for the
 # specific test.
 
-function_name = 'plp_power'
+function_name = 'plp_euclidean_distance'
 
 variables = [
-	SweepVariable('len', [128, 129, 130, 131, 1024]),
-  	SweepVariable('fp', [0, 1, 2, 4, 15], active=lambda v: 'q' in v),
+	SweepVariable('len', [128, 256, 512, 1024]),
+  	SweepVariable('fp', [2], active=lambda v: 'q' in v),
 ]
 
 arguments = [
-	ArrayArgument('pSrc', 'var_type', 'len', None),
-	Argument('blockSize', 'uint32_t', 'len'),
-  	FixPointArgument('deciPoint',  'fp'),
-  	ParallelArgument('nPE', 8),  
-	OutputArgument('pRes', 'ret_type', 1, tolerance=lambda v: 1e-3 if v.startswith('f') else 0),
+	ArrayArgument('srcA', 'var_type', 'len', (-10,10)),
+	ArrayArgument('srcB', 'var_type', 'len', (-10,10)),
+	Argument('length', 'uint32_t', 'len'),
+	FixPointArgument('deciPoint', 'fp'),
+	ParallelArgument('nPE', 8),
+	OutputArgument('res', 'ret_type', 1, tolerance=lambda v: 1e-3 if v.startswith('f') else 3),
 ]
 
 implemented = {
 	'riscy': {
-		'i32': True,
-		'i16': True,
-		'i8':  True,
+		'i32': False,
+		'i16': False,
+		'i8':  False,
 		'q32': True,
 		'q16': True,
-		'q8':  True,
+		'q8':  False,
 		'f32': True,
 		'i32_parallel': False,
 		'i16_parallel': False,
@@ -92,25 +93,15 @@ implemented = {
 		'f32_parallel': True
 	},
 	'ibex': {
-		'i32': True,
-		'i16': True,
-		'i8':  True,
+		'i32': False,
+		'i16': False,
+		'i8':  False,
 		'q32': True,
 		'q16': True,
-		'q8':  True,
+		'q8':  False,
 	}
 }
 
 n_ops = lambda env: env['len']
 
-arg_ret_type = {
-	'i32':   ('int32_t', 'int32_t'),
-	'i16':   ('int16_t', 'int32_t'),
-	'i8':    ('int8_t',  'int32_t'),
-	'q32':   ('int32_t', 'int32_t'),
-	'q16':   ('int16_t', 'int32_t'),
-	'q8':    ('int8_t',  'int32_t'),
-	'float': ('float',   'float')
-}
-
-TestConfig = c = generate_test(function_name, arguments, variables, implemented, use_l1=True, n_ops=n_ops, arg_ret_type=arg_ret_type)
+TestConfig = c = generate_test(function_name, arguments, variables, implemented, use_l1=True, n_ops=n_ops)


### PR DESCRIPTION
**Distance functions**

Add Distance function folder. Parallelization works fine on MrWolf for q32 and q16 kernels. 
The f32 version has limited speedup for a low number of input points due to the small number of FPU units per core and to the sequential nature of scalar sqrt and division.
